### PR TITLE
Add security configuration to Wikipedia examples

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -88,6 +88,10 @@ spec:
         port: 3001
         path: "/sse"
 
+  security:
+    runAsUser: 1000
+    runAsGroup: 1000
+
   resources:
     requests:
       cpu: "100m"
@@ -211,6 +215,10 @@ spec:
     minReplicas: 2
     maxReplicas: 10
     targetCPUUtilizationPercentage: 70
+
+  security:
+    runAsUser: 1000
+    runAsGroup: 1000
 
   resources:
     requests:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ spec:
         path: "/sse"
         sessionManagement: true
 
+  security:
+    runAsUser: 1000
+    runAsGroup: 1000
+
   resources:
     requests:
       cpu: "100m"


### PR DESCRIPTION
Update all Wikipedia MCP server examples in README.md and GETTING_STARTED.md to include proper security context configuration (runAsUser and runAsGroup) consistent with config/samples/wikipedia-http.yaml.

This ensures all examples demonstrate secure pod deployment practices.