### PR TITLE
Fix auto-detection to use protocol-specific paths when path is omitted

### DIFF
--- a/api/v1/mcpserver_types.go
+++ b/api/v1/mcpserver_types.go
@@ -437,7 +437,9 @@ type MCPHTTPTransportConfig struct {
 	Port int32 `json:"port,omitempty"`
 
 	// Path specifies the HTTP endpoint path
-	// +kubebuilder:default="/mcp"
+	// When omitted, auto-detection tries protocol-specific defaults:
+	// - "/mcp" for Streamable HTTP
+	// - "/sse" for SSE
 	// +optional
 	Path string `json:"path,omitempty"`
 

--- a/config/crd/bases/mcp.mcp-operator.io_mcpservers.yaml
+++ b/config/crd/bases/mcp.mcp-operator.io_mcpservers.yaml
@@ -3400,8 +3400,11 @@ spec:
                           SSE and standard HTTP)
                         properties:
                           path:
-                            default: /mcp
-                            description: Path specifies the HTTP endpoint path
+                            description: |-
+                              Path specifies the HTTP endpoint path
+                              When omitted, auto-detection tries protocol-specific defaults:
+                              - "/mcp" for Streamable HTTP
+                              - "/sse" for SSE
                             type: string
                           port:
                             default: 8080

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -3408,8 +3408,11 @@ spec:
                           SSE and standard HTTP)
                         properties:
                           path:
-                            default: /mcp
-                            description: Path specifies the HTTP endpoint path
+                            description: |-
+                              Path specifies the HTTP endpoint path
+                              When omitted, auto-detection tries protocol-specific defaults:
+                              - "/mcp" for Streamable HTTP
+                              - "/sse" for SSE
                             type: string
                           port:
                             default: 8080


### PR DESCRIPTION
Remove the kubebuilder default value of "/mcp" from HTTPConfig.Path field. This default was causing auto-detection to try "/mcp" for both Streamable HTTP and SSE protocols, preventing SSE servers from being detected.

Now when transport.config.http.path is omitted:
- Auto-detection tries "/mcp" for Streamable HTTP
- Auto-detection tries "/sse" for SSE protocol

This allows the operator to correctly detect servers that use the standard "/sse" path without requiring explicit path configuration.

Changes:
- Remove +kubebuilder:default="/mcp" annotation from HTTPConfig.Path
- Add documentation explaining auto-detection behavior
- Regenerate CRDs and install.yaml

Fixes issue where SSE servers at "/sse" path failed validation with: "tried Streamable HTTP at .../mcp and SSE at .../mcp"

🤖 Generated with [Claude Code](https://claude.com/claude-code)