### PR TITLE
Fix duplicate enum validation in ValidationState CRD

### DIFF
--- a/api/v1/mcpserver_types.go
+++ b/api/v1/mcpserver_types.go
@@ -512,7 +512,6 @@ type ValidationSpec struct {
 // ValidationStatus represents the MCP protocol validation status
 type ValidationStatus struct {
 	// State represents the overall validation state
-	// +kubebuilder:validation:Enum=Pending;Validating;Validated;AuthRequired;Failed;Disabled
 	// +optional
 	State ValidationState `json:"state,omitempty"`
 

--- a/config/crd/bases/mcp.mcp-operator.io_mcpservers.yaml
+++ b/config/crd/bases/mcp.mcp-operator.io_mcpservers.yaml
@@ -3599,22 +3599,14 @@ spec:
                     description: RequiresAuth indicates if the server requires authentication
                     type: boolean
                   state:
-                    allOf:
-                    - enum:
-                      - Pending
-                      - Validating
-                      - Validated
-                      - AuthRequired
-                      - Failed
-                      - Disabled
-                    - enum:
-                      - Pending
-                      - Validating
-                      - Validated
-                      - AuthRequired
-                      - Failed
-                      - Disabled
                     description: State represents the overall validation state
+                    enum:
+                    - Pending
+                    - Validating
+                    - Validated
+                    - AuthRequired
+                    - Failed
+                    - Disabled
                     type: string
                   validatedGeneration:
                     description: |-


### PR DESCRIPTION
Remove redundant kubebuilder:validation:Enum marker from State field since the ValidationState type already has the enum constraint.

This eliminates the duplicate allOf enum definitions in the generated CRD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)