### PR TITLE
Reorganize documentation for better clarity and navigation

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,910 @@
+# MCPServer API Reference
+
+Complete reference documentation for the `MCPServer` Custom Resource Definition (CRD).
+
+## Table of Contents
+
+- [Overview](#overview)
+- [MCPServerSpec](#mcpserverspec)
+  - [Core Fields](#core-fields)
+  - [Transport Configuration](#transport-configuration)
+  - [Resources](#resources)
+  - [Security](#security)
+  - [Service](#service)
+  - [Health Checks](#health-checks)
+  - [Environment Variables](#environment-variables)
+  - [Pod Template](#pod-template)
+  - [Horizontal Pod Autoscaler (HPA)](#horizontal-pod-autoscaler-hpa)
+  - [Validation](#validation)
+- [MCPServerStatus](#mcpserverstatus)
+- [Security Defaults](#security-defaults)
+
+## Overview
+
+The `MCPServer` resource defines an MCP (Model Context Protocol) server deployment in Kubernetes. The operator manages the complete lifecycle including deployment, scaling, validation, and monitoring.
+
+**API Group:** `mcp.mcp-operator.io/v1`
+
+**Kind:** `MCPServer`
+
+**Example:**
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: my-mcp-server
+spec:
+  image: "myregistry/mcp-server:latest"
+  replicas: 3
+  transport:
+    type: http
+    protocol: auto
+```
+
+## MCPServerSpec
+
+The `spec` section defines the desired state of your MCP server.
+
+### Core Fields
+
+#### `image` (required)
+
+- **Type:** `string`
+- **Description:** Container image for the MCP server
+- **Validation:** Must match pattern `^[a-z0-9]+(?:[._-][a-z0-9]+)*(?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)*(?::[a-zA-Z0-9][a-zA-Z0-9._-]*)?$`
+- **Example:**
+  ```yaml
+  image: "mcp/wikipedia-mcp:latest"
+  ```
+
+#### `command` (optional)
+
+- **Type:** `[]string`
+- **Description:** Override the container's default entrypoint
+- **Default:** Uses image's default ENTRYPOINT
+- **Example:**
+  ```yaml
+  command: ["python", "-m", "wikipedia_mcp"]
+  ```
+
+#### `args` (optional)
+
+- **Type:** `[]string`
+- **Description:** Override or append to the container's default arguments
+- **Default:** Uses image's default CMD
+- **Example:**
+  ```yaml
+  args: ["--transport", "sse", "--port", "8080", "--host", "0.0.0.0"]
+  ```
+
+#### `replicas` (optional)
+
+- **Type:** `int32`
+- **Description:** Number of MCP server instances to run
+- **Default:** `1`
+- **Validation:** Minimum value is `0`
+- **Example:**
+  ```yaml
+  replicas: 3
+  ```
+
+### Transport Configuration
+
+#### `transport` (optional)
+
+Defines the MCP transport configuration. If omitted, defaults to HTTP transport with auto-detection.
+
+**Type:** `object`
+
+**Fields:**
+
+##### `transport.type` (optional)
+
+- **Type:** `string`
+- **Description:** Transport layer type
+- **Valid Values:** `http`, `custom`
+- **Default:** `http`
+- **Example:**
+  ```yaml
+  transport:
+    type: http
+  ```
+
+##### `transport.protocol` (optional)
+
+- **Type:** `string`
+- **Description:** MCP protocol variant to use
+- **Valid Values:**
+  - `auto` - Auto-detect protocol (prefers Streamable HTTP over SSE)
+  - `streamable-http` - Use Streamable HTTP transport (MCP 2025-03-26+)
+  - `sse` - Use Server-Sent Events transport (MCP 2024-11-05)
+- **Default:** `auto`
+- **Example:**
+  ```yaml
+  transport:
+    protocol: auto
+  ```
+
+##### `transport.config` (optional)
+
+- **Type:** `object`
+- **Description:** Transport-specific configuration
+- **Fields:**
+
+###### `transport.config.http` (optional)
+
+HTTP transport configuration:
+
+- **`port`** (optional)
+  - **Type:** `int32`
+  - **Default:** `8080`
+  - **Validation:** Between 1 and 65535
+  - **Description:** Port for HTTP connections
+
+- **`path`** (optional)
+  - **Type:** `string`
+  - **Default:** Auto-detected (`/mcp` for Streamable HTTP, `/sse` for SSE)
+  - **Description:** HTTP endpoint path
+
+- **`sessionManagement`** (optional)
+  - **Type:** `bool`
+  - **Description:** Enable session management for the HTTP transport
+
+**Example:**
+
+```yaml
+transport:
+  type: http
+  protocol: auto
+  config:
+    http:
+      port: 8080
+      path: "/mcp"
+      sessionManagement: true
+```
+
+### Resources
+
+#### `resources` (optional)
+
+- **Type:** `object` (Kubernetes `ResourceRequirements`)
+- **Description:** CPU and memory resource requirements
+- **Default:** No resource limits or requests set
+- **Fields:**
+  - `requests` - Minimum resources needed
+    - `cpu` - CPU request (e.g., "200m", "1")
+    - `memory` - Memory request (e.g., "256Mi", "1Gi")
+  - `limits` - Maximum resources allowed
+    - `cpu` - CPU limit
+    - `memory` - Memory limit
+- **Example:**
+  ```yaml
+  resources:
+    requests:
+      cpu: "200m"
+      memory: "256Mi"
+    limits:
+      cpu: "1000m"
+      memory: "1Gi"
+  ```
+
+### Security
+
+#### `security` (optional)
+
+Security-related configuration for the MCP server. When omitted, the operator applies secure defaults compliant with [Kubernetes Pod Security Standards (Restricted)](https://kubernetes.io/docs/concepts/security/pod-security-standards/).
+
+**Type:** `object`
+
+**Fields:**
+
+##### `security.runAsUser` (optional)
+
+- **Type:** `int64`
+- **Description:** User ID to run the MCP server process
+- **Default:** `1000`
+- **Example:**
+  ```yaml
+  security:
+    runAsUser: 2000
+  ```
+
+##### `security.runAsGroup` (optional)
+
+- **Type:** `int64`
+- **Description:** Group ID to run the MCP server process
+- **Default:** `1000`
+- **Example:**
+  ```yaml
+  security:
+    runAsGroup: 2000
+  ```
+
+##### `security.runAsNonRoot` (optional)
+
+- **Type:** `bool`
+- **Description:** Indicates that the container must run as a non-root user
+- **Default:** `true`
+- **Example:**
+  ```yaml
+  security:
+    runAsNonRoot: true
+  ```
+
+##### `security.allowPrivilegeEscalation` (optional)
+
+- **Type:** `bool`
+- **Description:** Controls whether a process can gain more privileges than its parent
+- **Default:** `false`
+- **Example:**
+  ```yaml
+  security:
+    allowPrivilegeEscalation: false
+  ```
+
+##### `security.fsGroup` (optional)
+
+- **Type:** `int64`
+- **Description:** Special supplemental group for volume permissions
+- **Default:** `1000`
+- **Example:**
+  ```yaml
+  security:
+    fsGroup: 2000
+  ```
+
+##### `security.readOnlyRootFilesystem` (optional)
+
+- **Type:** `bool`
+- **Description:** Whether the container should have a read-only root filesystem
+- **Default:** Not set (container can write to root filesystem)
+- **Example:**
+  ```yaml
+  security:
+    readOnlyRootFilesystem: true
+  ```
+
+**Complete Example:**
+
+```yaml
+security:
+  runAsUser: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  fsGroup: 1000
+  readOnlyRootFilesystem: true
+```
+
+### Service
+
+#### `service` (optional)
+
+Defines how the MCP server is exposed as a Kubernetes service.
+
+**Type:** `object`
+
+**Fields:**
+
+##### `service.type` (optional)
+
+- **Type:** `string`
+- **Description:** Type of Kubernetes service
+- **Valid Values:** `ClusterIP`, `NodePort`, `LoadBalancer`
+- **Default:** `ClusterIP`
+- **Example:**
+  ```yaml
+  service:
+    type: ClusterIP
+  ```
+
+##### `service.port` (optional)
+
+- **Type:** `int32`
+- **Description:** Port on which the service listens
+- **Default:** `8080`
+- **Validation:** Between 1 and 65535
+- **Example:**
+  ```yaml
+  service:
+    port: 8080
+  ```
+
+##### `service.targetPort` (optional)
+
+- **Type:** `intstr.IntOrString`
+- **Description:** Container port to target (can be port number or name)
+- **Default:** Same as `service.port`
+- **Example:**
+  ```yaml
+  service:
+    targetPort: 8080
+  ```
+
+##### `service.protocol` (optional)
+
+- **Type:** `string`
+- **Description:** Network protocol
+- **Valid Values:** `TCP`, `UDP`
+- **Default:** `TCP`
+- **Example:**
+  ```yaml
+  service:
+    protocol: TCP
+  ```
+
+##### `service.annotations` (optional)
+
+- **Type:** `map[string]string`
+- **Description:** Annotations to add to the service (useful for cloud load balancers)
+- **Example:**
+  ```yaml
+  service:
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+  ```
+
+### Health Checks
+
+#### `healthCheck` (optional)
+
+Defines health check probe configuration for the MCP server.
+
+**Type:** `object`
+
+**Fields:**
+
+##### `healthCheck.enabled` (optional)
+
+- **Type:** `bool`
+- **Description:** Whether health checks should be performed
+- **Default:** `true`
+- **Example:**
+  ```yaml
+  healthCheck:
+    enabled: true
+  ```
+
+##### `healthCheck.path` (optional)
+
+- **Type:** `string`
+- **Description:** HTTP path for health checks
+- **Default:** `/health`
+- **Example:**
+  ```yaml
+  healthCheck:
+    path: "/health"
+  ```
+
+##### `healthCheck.port` (optional)
+
+- **Type:** `intstr.IntOrString`
+- **Description:** Port for health checks (can be port number or name)
+- **Default:** Uses the transport HTTP port
+- **Example:**
+  ```yaml
+  healthCheck:
+    port: 8080
+  ```
+
+### Environment Variables
+
+#### `environment` (optional)
+
+- **Type:** `[]object` (array of Kubernetes `EnvVar`)
+- **Description:** Environment variables for the MCP server
+- **Default:** Empty array
+- **Example:**
+  ```yaml
+  environment:
+    - name: LOG_LEVEL
+      value: "info"
+    - name: MCP_PORT
+      value: "8080"
+  ```
+
+For detailed information on environment variable configuration including ConfigMaps, Secrets, and best practices, see the [Environment Variables Guide](environment-variables.md).
+
+### Pod Template
+
+#### `podTemplate` (optional)
+
+Additional pod template specifications for advanced configuration.
+
+**Type:** `object`
+
+**Fields:**
+
+##### `podTemplate.labels` (optional)
+
+- **Type:** `map[string]string`
+- **Description:** Additional labels to add to pods
+- **Example:**
+  ```yaml
+  podTemplate:
+    labels:
+      monitoring: enabled
+  ```
+
+##### `podTemplate.annotations` (optional)
+
+- **Type:** `map[string]string`
+- **Description:** Additional annotations to add to pods
+- **Example:**
+  ```yaml
+  podTemplate:
+    annotations:
+      prometheus.io/scrape: "true"
+  ```
+
+##### `podTemplate.nodeSelector` (optional)
+
+- **Type:** `map[string]string`
+- **Description:** Node selection constraints
+- **Example:**
+  ```yaml
+  podTemplate:
+    nodeSelector:
+      disktype: ssd
+  ```
+
+##### `podTemplate.tolerations` (optional)
+
+- **Type:** `[]object` (array of Kubernetes `Toleration`)
+- **Description:** Pod tolerations for node taints
+- **Example:**
+  ```yaml
+  podTemplate:
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "mcp-servers"
+        effect: "NoSchedule"
+  ```
+
+##### `podTemplate.affinity` (optional)
+
+- **Type:** `object` (Kubernetes `Affinity`)
+- **Description:** Pod affinity and anti-affinity rules
+- **Example:**
+  ```yaml
+  podTemplate:
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values: ["my-mcp-server"]
+              topologyKey: kubernetes.io/hostname
+  ```
+
+##### `podTemplate.serviceAccountName` (optional)
+
+- **Type:** `string`
+- **Description:** Service account to use for the pod
+- **Example:**
+  ```yaml
+  podTemplate:
+    serviceAccountName: mcp-service-account
+  ```
+
+##### `podTemplate.imagePullSecrets` (optional)
+
+- **Type:** `[]object` (array of Kubernetes `LocalObjectReference`)
+- **Description:** Secrets for pulling container images
+- **Example:**
+  ```yaml
+  podTemplate:
+    imagePullSecrets:
+      - name: registry-credentials
+  ```
+
+##### `podTemplate.volumes` (optional)
+
+- **Type:** `[]object` (array of Kubernetes `Volume`)
+- **Description:** Additional volumes to mount
+- **Example:**
+  ```yaml
+  podTemplate:
+    volumes:
+      - name: config-volume
+        configMap:
+          name: mcp-config
+  ```
+
+##### `podTemplate.volumeMounts` (optional)
+
+- **Type:** `[]object` (array of Kubernetes `VolumeMount`)
+- **Description:** Volume mounts for the container
+- **Example:**
+  ```yaml
+  podTemplate:
+    volumeMounts:
+      - name: config-volume
+        mountPath: /etc/mcp/config
+        readOnly: true
+  ```
+
+### Horizontal Pod Autoscaler (HPA)
+
+#### `hpa` (optional)
+
+Horizontal Pod Autoscaler configuration for automatic scaling based on metrics.
+
+**Type:** `object`
+
+**Fields:**
+
+##### `hpa.enabled` (optional)
+
+- **Type:** `bool`
+- **Description:** Whether HPA should be created
+- **Default:** `false`
+- **Example:**
+  ```yaml
+  hpa:
+    enabled: true
+  ```
+
+##### `hpa.minReplicas` (optional)
+
+- **Type:** `int32`
+- **Description:** Lower limit for the number of replicas
+- **Default:** `1`
+- **Validation:** Minimum value is `1`
+- **Example:**
+  ```yaml
+  hpa:
+    minReplicas: 2
+  ```
+
+##### `hpa.maxReplicas` (optional)
+
+- **Type:** `int32`
+- **Description:** Upper limit for the number of replicas
+- **Default:** `10`
+- **Validation:** Minimum value is `1`
+- **Example:**
+  ```yaml
+  hpa:
+    maxReplicas: 20
+  ```
+
+##### `hpa.targetCPUUtilizationPercentage` (optional)
+
+- **Type:** `int32`
+- **Description:** Target average CPU utilization percentage
+- **Validation:** Between 1 and 100
+- **Example:**
+  ```yaml
+  hpa:
+    targetCPUUtilizationPercentage: 70
+  ```
+
+##### `hpa.targetMemoryUtilizationPercentage` (optional)
+
+- **Type:** `int32`
+- **Description:** Target average memory utilization percentage
+- **Validation:** Between 1 and 100
+- **Example:**
+  ```yaml
+  hpa:
+    targetMemoryUtilizationPercentage: 80
+  ```
+
+##### `hpa.scaleUpBehavior` (optional)
+
+- **Type:** `object`
+- **Description:** Configures scaling up behavior
+- **Fields:**
+  - `stabilizationWindowSeconds` (int32, 1-3600) - Seconds to consider past recommendations
+  - `policies` (array) - List of scaling policies
+    - `type` (string) - `Percent` or `Pods`
+    - `value` (int32, min 1) - Amount of change permitted
+    - `periodSeconds` (int32, 1-1800) - How long to hold the policy
+- **Example:**
+  ```yaml
+  hpa:
+    scaleUpBehavior:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: "Percent"
+          value: 100
+          periodSeconds: 15
+  ```
+
+##### `hpa.scaleDownBehavior` (optional)
+
+- **Type:** `object`
+- **Description:** Configures scaling down behavior
+- **Fields:** Same as `scaleUpBehavior`
+- **Example:**
+  ```yaml
+  hpa:
+    scaleDownBehavior:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: "Pods"
+          value: 1
+          periodSeconds: 60
+  ```
+
+### Validation
+
+#### `validation` (optional)
+
+MCP protocol validation configuration. **IMPORTANT:** Validation is **ENABLED BY DEFAULT** even when this field is omitted.
+
+**Type:** `object`
+
+**Fields:**
+
+##### `validation.enabled` (optional)
+
+- **Type:** `bool`
+- **Description:** Whether protocol validation should be performed
+- **Default:** `true` (validation runs even when `spec.validation` is omitted)
+- **Note:** Set to `false` to explicitly disable all validation
+- **Example:**
+  ```yaml
+  validation:
+    enabled: false
+  ```
+
+##### `validation.transportProtocol` (optional)
+
+- **Type:** `string`
+- **Description:** Which transport protocol to validate against
+- **Valid Values:** `auto`, `streamable-http`, `sse`
+- **Default:** Uses `spec.transport.protocol`
+- **Example:**
+  ```yaml
+  validation:
+    transportProtocol: auto
+  ```
+
+##### `validation.strictMode` (optional)
+
+- **Type:** `bool`
+- **Description:** Fail deployment if validation fails
+- **Default:** `false` (deployment continues, issues reported in status)
+- **Behavior:** When `true`, MCPServer phase becomes "ValidationFailed" and deployment scales to 0
+- **Example:**
+  ```yaml
+  validation:
+    strictMode: true
+  ```
+
+##### `validation.requiredCapabilities` (optional)
+
+- **Type:** `[]string`
+- **Description:** Capabilities that must be present for validation to succeed
+- **Valid Values:** `tools`, `resources`, `prompts`
+- **Default:** Empty (no required capabilities)
+- **Example:**
+  ```yaml
+  validation:
+    requiredCapabilities:
+      - "tools"
+      - "resources"
+  ```
+
+**Complete Example:**
+
+```yaml
+validation:
+  enabled: true
+  transportProtocol: auto
+  strictMode: false
+  requiredCapabilities:
+    - "tools"
+    - "resources"
+```
+
+For comprehensive details on validation behavior, see the [Validation Behavior Guide](validation-behavior.md).
+
+## MCPServerStatus
+
+The `status` section reflects the observed state of the MCP server.
+
+### Status Fields
+
+#### `phase` (string)
+
+Current phase of the MCP server deployment.
+
+**Valid Values:**
+- `Pending` - MCP server is pending creation
+- `Creating` - MCP server is being created
+- `Running` - MCP server is running normally
+- `Scaling` - MCP server is scaling up or down
+- `Updating` - MCP server is being updated
+- `Failed` - MCP server deployment failed
+- `ValidationFailed` - Validation failed in strict mode
+- `Terminating` - MCP server is being terminated
+
+#### `message` (string)
+
+Additional information about the current phase.
+
+#### `replicas` (int32)
+
+Current number of running replicas.
+
+#### `readyReplicas` (int32)
+
+Number of ready replicas.
+
+#### `availableReplicas` (int32)
+
+Number of available replicas.
+
+#### `serviceEndpoint` (string)
+
+Endpoint where the MCP server is accessible (e.g., `http://my-server.default.svc:8080/mcp`).
+
+#### `transportType` (string)
+
+Active transport type (e.g., `http`).
+
+#### `lastReconcileTime` (timestamp)
+
+Last time the MCP server was reconciled.
+
+#### `observedGeneration` (int64)
+
+Most recent generation observed by the controller.
+
+### Validation Status
+
+#### `validation` (object)
+
+MCP protocol validation status.
+
+**Fields:**
+
+##### `validation.state` (string)
+
+Overall validation state.
+
+**Valid Values:**
+- `Pending` - Validation has not started
+- `Validating` - Validation is in progress
+- `Validated` - Validation succeeded, server is compliant
+- `AuthRequired` - Server requires authentication
+- `Failed` - Validation ran but found issues
+- `Disabled` - User disabled validation
+
+##### `validation.compliant` (bool)
+
+Whether the server is protocol compliant.
+
+##### `validation.protocol` (string)
+
+Detected MCP protocol variant (e.g., `streamable-http`, `sse`).
+
+##### `validation.protocolVersion` (string)
+
+Detected MCP specification version (e.g., `2024-11-05`, `2025-03-26`).
+
+##### `validation.endpoint` (string)
+
+Full URL that was validated.
+
+##### `validation.requiresAuth` (bool)
+
+Whether the server requires authentication.
+
+##### `validation.capabilities` ([]string)
+
+Capabilities discovered from the server (e.g., `["tools", "resources", "prompts"]`).
+
+##### `validation.attempts` (int32)
+
+Number of validation attempts made.
+
+##### `validation.lastAttemptTime` (timestamp)
+
+Timestamp of the last validation attempt.
+
+##### `validation.lastValidated` (timestamp)
+
+Timestamp of the last successful validation.
+
+##### `validation.validatedGeneration` (int64)
+
+Generation of the MCPServer that was validated.
+
+##### `validation.issues` ([]object)
+
+Validation issues found (if any).
+
+**Issue Fields:**
+- `level` (string) - Severity: `error`, `warning`, `info`
+- `message` (string) - Human-readable description
+- `code` (string) - Machine-readable issue code
+
+**Example Status:**
+
+```yaml
+status:
+  phase: Running
+  replicas: 3
+  readyReplicas: 3
+  availableReplicas: 3
+  serviceEndpoint: "http://my-mcp-server.default.svc:8080/mcp"
+  transportType: http
+  validation:
+    state: Validated
+    compliant: true
+    protocol: "streamable-http"
+    protocolVersion: "2025-03-26"
+    endpoint: "http://my-mcp-server.default.svc:8080/mcp"
+    requiresAuth: false
+    capabilities: ["tools", "resources", "prompts"]
+    lastValidated: "2025-12-03T10:00:00Z"
+    validatedGeneration: 1
+```
+
+### Conditions
+
+#### `conditions` ([]object)
+
+Detailed status conditions following Kubernetes conventions.
+
+**Condition Types:**
+- `Ready` - MCP server is ready to serve traffic
+- `Available` - MCP server has minimum required replicas available
+- `Progressing` - MCP server is progressing towards desired state
+- `Degraded` - MCP server is in a degraded state
+- `Reconciled` - MCP server has been successfully reconciled
+
+**Condition Fields:**
+- `type` (string) - Condition type
+- `status` (string) - `True`, `False`, or `Unknown`
+- `lastTransitionTime` (timestamp) - When the condition last changed
+- `reason` (string) - One-word CamelCase reason for transition
+- `message` (string) - Human-readable message about the transition
+
+## Security Defaults
+
+The operator automatically applies secure defaults compliant with Kubernetes [Pod Security Standards (Restricted)](https://kubernetes.io/docs/concepts/security/pod-security-standards/) when `spec.security` is not specified.
+
+**Default Security Context:**
+
+```yaml
+security:
+  runAsNonRoot: true           # Containers must run as non-root
+  runAsUser: 1000              # Default non-root user ID
+  runAsGroup: 1000             # Default group ID
+  fsGroup: 1000                # File system group for volume permissions
+  allowPrivilegeEscalation: false  # No privilege escalation
+```
+
+**Additional Container Security:**
+- All Linux capabilities are dropped (`capabilities: drop: ["ALL"]`)
+- Default seccomp profile is applied (`seccompProfile: RuntimeDefault`)
+
+**Overriding Defaults:**
+
+You only need to specify security settings if you want to override the defaults. Partial configurations are supported - unspecified fields will use the secure defaults.
+
+```yaml
+spec:
+  security:
+    runAsUser: 2000              # Override default user
+    readOnlyRootFilesystem: true # Add read-only root filesystem
+    # Other fields use secure defaults
+```
+
+## See Also
+
+- [Configuration Guide](configuration-guide.md) - Configuration patterns and examples
+- [Environment Variables Guide](environment-variables.md) - Environment variable configuration
+- [Validation Behavior Guide](validation-behavior.md) - Protocol validation deep dive
+- [Configuration Examples](../config/samples/) - Real-world YAML examples

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -1,0 +1,1201 @@
+# Configuration Guide
+
+Complete guide to configuring MCP servers with patterns and examples for different use cases.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Configuration by Environment](#configuration-by-environment)
+- [Transport Configuration](#transport-configuration)
+- [Resource Sizing](#resource-sizing)
+- [Scaling Strategies](#scaling-strategies)
+- [Security Configurations](#security-configurations)
+- [Service Exposure](#service-exposure)
+- [Pod Template Advanced Features](#pod-template-advanced-features)
+- [Multi-Environment with Kustomize](#multi-environment-with-kustomize)
+- [Best Practices](#best-practices)
+
+## Overview
+
+MCPServer resources can be configured for different use cases from development to production. This guide provides practical patterns and complete examples.
+
+## Configuration by Environment
+
+### Development Configuration
+
+Minimal configuration optimized for local development and testing:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-dev
+  namespace: development
+spec:
+  image: "myregistry/mcp-server:latest"
+
+  # Single replica for development
+  replicas: 1
+
+  # Auto-detect protocol
+  transport:
+    type: http
+    protocol: auto
+    config:
+      http:
+        port: 8080
+        path: "/mcp"
+
+  # Minimal resources
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+
+  # Debug logging
+  environment:
+    - name: LOG_LEVEL
+      value: "debug"
+    - name: ENVIRONMENT
+      value: "development"
+
+  # Validation enabled but not strict
+  validation:
+    enabled: true
+    strictMode: false
+```
+
+### Staging Configuration
+
+Configuration for pre-production testing:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-staging
+  namespace: staging
+spec:
+  image: "myregistry/mcp-server:v1.2.0"
+
+  # Multiple replicas for testing HA
+  replicas: 2
+
+  # Explicit protocol for consistency
+  transport:
+    type: http
+    protocol: streamable-http
+    config:
+      http:
+        port: 8080
+        path: "/mcp"
+        sessionManagement: true
+
+  # Production-like resources
+  resources:
+    requests:
+      cpu: "200m"
+      memory: "256Mi"
+    limits:
+      cpu: "1000m"
+      memory: "1Gi"
+
+  # Info logging
+  environment:
+    - name: LOG_LEVEL
+      value: "info"
+    - name: ENVIRONMENT
+      value: "staging"
+    - name: METRICS_ENABLED
+      value: "true"
+
+  # Strict validation in staging
+  validation:
+    enabled: true
+    strictMode: true
+    requiredCapabilities:
+      - "tools"
+      - "resources"
+
+  # Security context
+  security:
+    runAsUser: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+```
+
+### Production Configuration
+
+Full production configuration with all safety features:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-production
+  namespace: production
+  labels:
+    app.kubernetes.io/name: mcp-operator
+    environment: production
+spec:
+  image: "myregistry/mcp-server:v1.2.0"
+
+  # High availability with HPA
+  replicas: 3
+
+  hpa:
+    enabled: true
+    minReplicas: 3
+    maxReplicas: 20
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 80
+
+    # Conservative scale-up
+    scaleUpBehavior:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: "Percent"
+          value: 50
+          periodSeconds: 30
+
+    # Gradual scale-down
+    scaleDownBehavior:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: "Pods"
+          value: 1
+          periodSeconds: 120
+
+  # Explicit protocol
+  transport:
+    type: http
+    protocol: streamable-http
+    config:
+      http:
+        port: 8080
+        path: "/mcp"
+        sessionManagement: true
+
+  # Production resources
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "512Mi"
+    limits:
+      cpu: "2000m"
+      memory: "2Gi"
+
+  # Production environment vars
+  environment:
+    - name: LOG_LEVEL
+      value: "warn"
+    - name: ENVIRONMENT
+      value: "production"
+    - name: METRICS_ENABLED
+      value: "true"
+    - name: API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: mcp-secrets
+          key: api-key
+
+  # Strict validation
+  validation:
+    enabled: true
+    strictMode: true
+    requiredCapabilities:
+      - "tools"
+      - "resources"
+
+  # Full security context
+  security:
+    runAsUser: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    fsGroup: 1000
+    readOnlyRootFilesystem: true
+
+  # Health checks
+  healthCheck:
+    enabled: true
+    path: "/health"
+    port: 8080
+
+  # Pod template for production
+  podTemplate:
+    labels:
+      monitoring: enabled
+
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "8080"
+
+    # Spread across nodes
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/instance
+                    operator: In
+                    values:
+                      - mcp-production
+              topologyKey: kubernetes.io/hostname
+```
+
+## Transport Configuration
+
+### Auto-Detection (Recommended)
+
+Let the operator detect the protocol automatically:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-auto
+spec:
+  image: "mcp/server:latest"
+
+  transport:
+    type: http
+    protocol: auto  # Prefers Streamable HTTP over SSE
+    config:
+      http:
+        port: 8080
+        # Path will be auto-detected
+        # Tries /mcp first, then /sse
+```
+
+### Explicit Streamable HTTP (Modern)
+
+Force Streamable HTTP protocol (MCP 2025-03-26+):
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-streamable
+spec:
+  image: "mcp/modern-server:latest"
+
+  transport:
+    type: http
+    protocol: streamable-http
+    config:
+      http:
+        port: 8080
+        path: "/mcp"
+        sessionManagement: true
+```
+
+### Explicit SSE (Legacy)
+
+Force Server-Sent Events protocol (MCP 2024-11-05):
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-sse
+spec:
+  image: "mcp/wikipedia-mcp:latest"
+  command: ["python", "-m", "wikipedia_mcp"]
+  args: ["--transport", "sse", "--port", "3001", "--host", "0.0.0.0"]
+
+  transport:
+    type: http
+    protocol: sse
+    config:
+      http:
+        port: 3001
+        path: "/sse"
+```
+
+### When to Use Which Protocol
+
+**Use `auto` when:**
+- You're not sure which protocol your server supports
+- Your server supports multiple protocols
+- You want the operator to handle protocol selection
+
+**Use `streamable-http` when:**
+- You know your server uses modern Streamable HTTP
+- You want to ensure only Streamable HTTP is used
+- You're deploying new MCP servers (recommended)
+
+**Use `sse` when:**
+- You're working with legacy MCP servers
+- Your server only supports SSE
+- You need compatibility with older MCP clients
+
+## Resource Sizing
+
+### Small Workloads
+
+Suitable for development, testing, or low-traffic services:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-small
+spec:
+  image: "myregistry/mcp-server:latest"
+  replicas: 1
+
+  resources:
+    requests:
+      cpu: "100m"      # 0.1 CPU cores
+      memory: "128Mi"  # 128 megabytes
+    limits:
+      cpu: "500m"      # 0.5 CPU cores
+      memory: "512Mi"  # 512 megabytes
+```
+
+**Characteristics:**
+- Single replica or 2 for basic HA
+- Minimal resource usage
+- Suitable for <10 requests/second
+
+### Medium Workloads
+
+Suitable for production services with moderate traffic:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-medium
+spec:
+  image: "myregistry/mcp-server:latest"
+  replicas: 3
+
+  resources:
+    requests:
+      cpu: "200m"      # 0.2 CPU cores
+      memory: "256Mi"  # 256 megabytes
+    limits:
+      cpu: "1000m"     # 1 CPU core
+      memory: "1Gi"    # 1 gigabyte
+
+  # Optional: Enable HPA
+  hpa:
+    enabled: true
+    minReplicas: 3
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+```
+
+**Characteristics:**
+- 3+ replicas for high availability
+- Moderate resource allocation
+- Can handle 10-100 requests/second
+- HPA recommended for traffic spikes
+
+### Large Workloads
+
+Suitable for high-traffic production services:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-large
+spec:
+  image: "myregistry/mcp-server:latest"
+  replicas: 5
+
+  resources:
+    requests:
+      cpu: "500m"      # 0.5 CPU cores
+      memory: "512Mi"  # 512 megabytes
+    limits:
+      cpu: "2000m"     # 2 CPU cores
+      memory: "2Gi"    # 2 gigabytes
+
+  # HPA essential for large workloads
+  hpa:
+    enabled: true
+    minReplicas: 5
+    maxReplicas: 50
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 80
+
+    scaleUpBehavior:
+      stabilizationWindowSeconds: 30
+      policies:
+        - type: "Percent"
+          value: 100
+          periodSeconds: 15
+
+    scaleDownBehavior:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: "Pods"
+          value: 2
+          periodSeconds: 60
+```
+
+**Characteristics:**
+- 5+ baseline replicas
+- Significant resource allocation
+- Can handle 100+ requests/second
+- Aggressive scaling policies
+
+## Scaling Strategies
+
+### Static Replicas
+
+Fixed number of replicas (simplest approach):
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-static
+spec:
+  image: "myregistry/mcp-server:latest"
+  replicas: 3  # Always 3 replicas
+```
+
+**When to use:**
+- Predictable traffic patterns
+- Cost optimization with fixed capacity
+- Development/staging environments
+
+### Basic HPA
+
+Simple autoscaling based on CPU:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-hpa-basic
+spec:
+  image: "myregistry/mcp-server:latest"
+  replicas: 3  # Initial replicas (used as min when HPA disabled)
+
+  resources:
+    requests:
+      cpu: "200m"
+      memory: "256Mi"
+    limits:
+      cpu: "1000m"
+      memory: "1Gi"
+
+  hpa:
+    enabled: true
+    minReplicas: 3
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+```
+
+**When to use:**
+- Variable traffic patterns
+- CPU-bound workloads
+- Simple scaling requirements
+
+### Advanced HPA
+
+Complex autoscaling with custom policies:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-hpa-advanced
+spec:
+  image: "myregistry/mcp-server:latest"
+
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "512Mi"
+    limits:
+      cpu: "2000m"
+      memory: "2Gi"
+
+  hpa:
+    enabled: true
+    minReplicas: 5
+    maxReplicas: 50
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 80
+
+    # Fast scale-up for traffic spikes
+    scaleUpBehavior:
+      stabilizationWindowSeconds: 30
+      policies:
+        # Add up to 100% of current pods every 15s
+        - type: "Percent"
+          value: 100
+          periodSeconds: 15
+        # Or add up to 5 pods every 15s
+        - type: "Pods"
+          value: 5
+          periodSeconds: 15
+
+    # Gradual scale-down to prevent flapping
+    scaleDownBehavior:
+      stabilizationWindowSeconds: 300  # 5 minutes
+      policies:
+        # Remove max 10% of current pods every 60s
+        - type: "Percent"
+          value: 10
+          periodSeconds: 60
+        # Or remove max 1 pod every 60s
+        - type: "Pods"
+          value: 1
+          periodSeconds: 60
+```
+
+**When to use:**
+- Unpredictable traffic with rapid spikes
+- Need to optimize for both cost and performance
+- Production environments with SLAs
+
+## Security Configurations
+
+### Default Security (Recommended)
+
+Use operator's secure defaults (no spec.security needed):
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-secure-default
+spec:
+  image: "myregistry/mcp-server:latest"
+  # No security section = secure defaults applied
+```
+
+**Defaults applied:**
+- `runAsNonRoot: true`
+- `runAsUser: 1000`
+- `runAsGroup: 1000`
+- `fsGroup: 1000`
+- `allowPrivilegeEscalation: false`
+- Capabilities dropped: `ALL`
+- Seccomp profile: `RuntimeDefault`
+
+### Custom Security Context
+
+Override specific security settings:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-custom-security
+spec:
+  image: "myregistry/mcp-server:latest"
+
+  security:
+    runAsUser: 2000               # Custom user ID
+    runAsGroup: 2000              # Custom group ID
+    fsGroup: 2000                 # Custom fsGroup
+    runAsNonRoot: true            # Still non-root
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true  # Add read-only root
+```
+
+### Read-Only Root Filesystem
+
+Maximum security with read-only root filesystem:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-readonly
+spec:
+  image: "myregistry/mcp-server:latest"
+
+  security:
+    runAsUser: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+
+  # Provide writable directories where needed
+  podTemplate:
+    volumes:
+      - name: tmp-volume
+        emptyDir: {}
+      - name: cache-volume
+        emptyDir:
+          sizeLimit: 1Gi
+
+    volumeMounts:
+      - name: tmp-volume
+        mountPath: /tmp
+      - name: cache-volume
+        mountPath: /var/cache/mcp
+```
+
+### Pod Security Standards Compliance
+
+Ensure compliance with Kubernetes Pod Security Standards:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-pss-restricted
+  namespace: restricted-namespace
+spec:
+  image: "myregistry/mcp-server:latest"
+
+  # Restricted Pod Security Standard requirements
+  security:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+
+  # No privileged containers, hostNetwork, hostPID, hostIPC
+  # All capabilities dropped (handled by operator)
+```
+
+## Service Exposure
+
+### ClusterIP (Default)
+
+Internal cluster access only:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-clusterip
+spec:
+  image: "myregistry/mcp-server:latest"
+
+  service:
+    type: ClusterIP  # Default
+    port: 8080
+```
+
+**Use case:** Services accessed only from within the cluster.
+
+### NodePort
+
+Access via node IP and static port:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-nodeport
+spec:
+  image: "myregistry/mcp-server:latest"
+
+  service:
+    type: NodePort
+    port: 8080
+    # Kubernetes assigns a port in range 30000-32767
+```
+
+**Use case:** Development/testing with direct node access.
+
+### LoadBalancer
+
+Cloud load balancer (AWS/GCP/Azure):
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-loadbalancer
+spec:
+  image: "myregistry/mcp-server:latest"
+
+  service:
+    type: LoadBalancer
+    port: 8080
+    annotations:
+      # AWS
+      service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+      service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
+
+      # GCP
+      cloud.google.com/load-balancer-type: "Internal"
+
+      # Azure
+      service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+```
+
+**Use case:** Production external access with cloud provider integration.
+
+### Custom Port Mapping
+
+Custom port configuration:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-custom-ports
+spec:
+  image: "myregistry/mcp-server:latest"
+
+  service:
+    type: ClusterIP
+    port: 80          # Service port (what clients connect to)
+    targetPort: 8080  # Container port (what server listens on)
+    protocol: TCP
+```
+
+## Pod Template Advanced Features
+
+### Node Selectors
+
+Schedule pods on specific nodes:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-node-selector
+spec:
+  image: "myregistry/mcp-server:latest"
+
+  podTemplate:
+    nodeSelector:
+      disktype: ssd           # Nodes with SSD storage
+      workload-type: mcp      # Nodes designated for MCP workloads
+```
+
+### Tolerations
+
+Allow pods on tainted nodes:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-tolerations
+spec:
+  image: "myregistry/mcp-server:latest"
+
+  podTemplate:
+    tolerations:
+      # Tolerate dedicated nodes
+      - key: "dedicated"
+        operator: "Equal"
+        value: "mcp-servers"
+        effect: "NoSchedule"
+
+      # Tolerate nodes with specific effects
+      - key: "high-priority"
+        operator: "Exists"
+        effect: "PreferNoSchedule"
+```
+
+### Affinity Rules
+
+Control pod placement with affinity:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-affinity
+spec:
+  image: "myregistry/mcp-server:latest"
+
+  podTemplate:
+    affinity:
+      # Spread pods across nodes
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/instance
+                    operator: In
+                    values:
+                      - mcp-affinity
+              topologyKey: kubernetes.io/hostname
+
+      # Prefer nodes with specific characteristics
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 50
+            preference:
+              matchExpressions:
+                - key: node-role.kubernetes.io/worker
+                  operator: Exists
+```
+
+### Custom Service Accounts
+
+Use custom service account with specific permissions:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mcp-service-account
+  namespace: production
+---
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-custom-sa
+  namespace: production
+spec:
+  image: "myregistry/mcp-server:latest"
+
+  podTemplate:
+    serviceAccountName: mcp-service-account
+```
+
+### Image Pull Secrets
+
+Pull images from private registries:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-private-registry
+spec:
+  image: "private-registry.example.com/mcp-server:latest"
+
+  podTemplate:
+    imagePullSecrets:
+      - name: registry-credentials
+      - name: docker-hub-credentials
+```
+
+## Multi-Environment with Kustomize
+
+Use Kustomize to manage configurations across environments.
+
+### Directory Structure
+
+```
+kustomize/
+├── base/
+│   ├── kustomization.yaml
+│   └── mcpserver.yaml
+├── overlays/
+│   ├── development/
+│   │   ├── kustomization.yaml
+│   │   └── patches.yaml
+│   ├── staging/
+│   │   ├── kustomization.yaml
+│   │   └── patches.yaml
+│   └── production/
+│       ├── kustomization.yaml
+│       └── patches.yaml
+```
+
+### Base Configuration
+
+`base/mcpserver.yaml`:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-server
+spec:
+  image: "myregistry/mcp-server:latest"
+
+  transport:
+    type: http
+    protocol: auto
+    config:
+      http:
+        port: 8080
+
+  resources:
+    requests:
+      cpu: "200m"
+      memory: "256Mi"
+    limits:
+      cpu: "1000m"
+      memory: "1Gi"
+```
+
+`base/kustomization.yaml`:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - mcpserver.yaml
+```
+
+### Development Overlay
+
+`overlays/development/kustomization.yaml`:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: development
+
+bases:
+  - ../../base
+
+patchesStrategicMerge:
+  - patches.yaml
+
+commonLabels:
+  environment: development
+```
+
+`overlays/development/patches.yaml`:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-server
+spec:
+  replicas: 1
+
+  environment:
+    - name: LOG_LEVEL
+      value: "debug"
+    - name: ENVIRONMENT
+      value: "development"
+```
+
+### Production Overlay
+
+`overlays/production/kustomization.yaml`:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: production
+
+bases:
+  - ../../base
+
+patchesStrategicMerge:
+  - patches.yaml
+
+commonLabels:
+  environment: production
+```
+
+`overlays/production/patches.yaml`:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: mcp-server
+spec:
+  replicas: 5
+
+  hpa:
+    enabled: true
+    minReplicas: 5
+    maxReplicas: 20
+    targetCPUUtilizationPercentage: 70
+
+  security:
+    runAsUser: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+
+  environment:
+    - name: LOG_LEVEL
+      value: "warn"
+    - name: ENVIRONMENT
+      value: "production"
+```
+
+### Deploy with Kustomize
+
+```bash
+# Development
+kubectl apply -k overlays/development
+
+# Staging
+kubectl apply -k overlays/staging
+
+# Production
+kubectl apply -k overlays/production
+```
+
+## Best Practices
+
+### 1. Start Simple, Scale as Needed
+
+Begin with minimal configuration and add complexity as requirements grow:
+
+```yaml
+# Start with this
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: my-server
+spec:
+  image: "myregistry/mcp-server:latest"
+
+# Add features gradually:
+# - Resource limits
+# - HPA
+# - Security contexts
+# - Pod affinity
+# - etc.
+```
+
+### 2. Always Set Resource Limits
+
+Prevent resource exhaustion:
+
+```yaml
+resources:
+  requests:  # Guaranteed resources
+    cpu: "200m"
+    memory: "256Mi"
+  limits:    # Maximum resources
+    cpu: "1000m"
+    memory: "1Gi"
+```
+
+### 3. Enable Health Checks
+
+Ensure Kubernetes can monitor server health:
+
+```yaml
+healthCheck:
+  enabled: true
+  path: "/health"
+  port: 8080
+```
+
+### 4. Use Strict Validation in Production
+
+Catch issues early:
+
+```yaml
+validation:
+  enabled: true
+  strictMode: true  # Fail deployment if validation fails
+  requiredCapabilities:
+    - "tools"
+    - "resources"
+```
+
+### 5. Implement Pod Anti-Affinity
+
+Spread replicas across nodes for high availability:
+
+```yaml
+podTemplate:
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values: ["my-server"]
+            topologyKey: kubernetes.io/hostname
+```
+
+### 6. Use Secrets for Sensitive Data
+
+Never hardcode credentials:
+
+```yaml
+environment:
+  - name: API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: mcp-secrets
+        key: api-key
+```
+
+### 7. Tag Images with Versions
+
+Avoid `latest` tag in production:
+
+```yaml
+# ✅ Good
+image: "myregistry/mcp-server:v1.2.0"
+
+# ❌ Bad for production
+image: "myregistry/mcp-server:latest"
+```
+
+### 8. Monitor Your Servers
+
+Enable metrics collection:
+
+```yaml
+podTemplate:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8080"
+
+environment:
+  - name: METRICS_ENABLED
+    value: "true"
+```
+
+### 9. Use Namespaces
+
+Organize resources by environment or team:
+
+```bash
+kubectl create namespace mcp-production
+kubectl create namespace mcp-staging
+kubectl create namespace mcp-development
+```
+
+### 10. Document Your Configuration
+
+Add annotations and labels:
+
+```yaml
+metadata:
+  name: my-server
+  annotations:
+    description: "MCP server for customer support"
+    owner: "platform-team"
+    docs: "https://wiki.example.com/mcp-server"
+  labels:
+    app.kubernetes.io/name: mcp-server
+    app.kubernetes.io/version: "1.2.0"
+    environment: production
+```
+
+## See Also
+
+- [API Reference](api-reference.md) - Complete field documentation
+- [Environment Variables Guide](environment-variables.md) - Environment variable configuration
+- [Validation Behavior](validation-behavior.md) - Protocol validation details
+- [Troubleshooting Guide](troubleshooting.md) - Common issues and solutions
+- [Monitoring Guide](monitoring.md) - Metrics and observability
+- [Configuration Examples](../config/samples/) - Real-world YAML examples

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,739 @@
+# Environment Variables Guide
+
+This guide covers how to configure environment variables for your MCP servers running in Kubernetes with the MCP Operator.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Basic Configuration](#basic-configuration)
+- [Using ConfigMaps](#using-configmaps)
+- [Using Secrets](#using-secrets)
+- [Volume Mounts for Configuration Files](#volume-mounts-for-configuration-files)
+- [Common Environment Variables](#common-environment-variables)
+- [Best Practices](#best-practices)
+- [Troubleshooting](#troubleshooting)
+
+## Overview
+
+Environment variables are configured through the `spec.environment` field in your MCPServer resource. This field accepts standard Kubernetes `EnvVar` objects, giving you flexibility in how you provide configuration to your MCP servers.
+
+## Basic Configuration
+
+The simplest way to configure environment variables is to specify them directly in the MCPServer spec.
+
+### Direct Value Specification
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: my-mcp-server
+spec:
+  image: "myregistry/mcp-server:latest"
+
+  environment:
+    - name: LOG_LEVEL
+      value: "info"
+    - name: MCP_PORT
+      value: "8080"
+    - name: METRICS_ENABLED
+      value: "true"
+    - name: ENVIRONMENT
+      value: "production"
+```
+
+### Field References
+
+You can reference pod or container fields using `fieldRef`:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: my-mcp-server
+spec:
+  image: "myregistry/mcp-server:latest"
+
+  environment:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    - name: NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+```
+
+### Resource Field References
+
+Reference container resource limits or requests:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: my-mcp-server
+spec:
+  image: "myregistry/mcp-server:latest"
+
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "200m"
+    limits:
+      memory: "1Gi"
+      cpu: "1000m"
+
+  environment:
+    - name: MEMORY_LIMIT
+      valueFrom:
+        resourceFieldRef:
+          containerName: mcp-server
+          resource: limits.memory
+          divisor: "1Mi"
+    - name: CPU_REQUEST
+      valueFrom:
+        resourceFieldRef:
+          containerName: mcp-server
+          resource: requests.cpu
+```
+
+## Using ConfigMaps
+
+ConfigMaps are ideal for non-sensitive configuration data. They allow you to manage configuration separately from your MCPServer definition.
+
+### Create a ConfigMap
+
+First, create a ConfigMap with your configuration:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-server-config
+data:
+  log_level: "info"
+  max_connections: "100"
+  timeout: "30s"
+  feature_flags: "feature1,feature2,feature3"
+```
+
+Apply it:
+
+```bash
+kubectl apply -f configmap.yaml
+```
+
+### Reference ConfigMap Values
+
+Reference individual keys from the ConfigMap:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: my-mcp-server
+spec:
+  image: "myregistry/mcp-server:latest"
+
+  environment:
+    - name: LOG_LEVEL
+      valueFrom:
+        configMapKeyRef:
+          name: mcp-server-config
+          key: log_level
+    - name: MAX_CONNECTIONS
+      valueFrom:
+        configMapKeyRef:
+          name: mcp-server-config
+          key: max_connections
+    - name: TIMEOUT
+      valueFrom:
+        configMapKeyRef:
+          name: mcp-server-config
+          key: timeout
+```
+
+### Import All ConfigMap Keys
+
+Import all keys from a ConfigMap as environment variables:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: my-mcp-server
+spec:
+  image: "myregistry/mcp-server:latest"
+
+  podTemplate:
+    # Note: envFrom is not directly supported in spec.environment,
+    # but you can use podTemplate for advanced scenarios
+    # This requires using the pod spec directly
+```
+
+**Note:** The `spec.environment` field only supports individual `EnvVar` entries. For bulk import of ConfigMap or Secret keys, you would need to list them individually or consider using init containers or configuration files mounted as volumes.
+
+## Using Secrets
+
+Secrets are designed for sensitive data like API keys, passwords, and tokens. They provide better security than ConfigMaps.
+
+### Create a Secret
+
+Create a Secret with your sensitive data:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mcp-server-secrets
+type: Opaque
+stringData:
+  api-key: "super-secret-api-key"
+  db-password: "database-password"
+  oauth-token: "oauth-token-value"
+```
+
+Apply it:
+
+```bash
+kubectl apply -f secret.yaml
+```
+
+Or create it from literals:
+
+```bash
+kubectl create secret generic mcp-server-secrets \
+  --from-literal=api-key=super-secret-api-key \
+  --from-literal=db-password=database-password
+```
+
+### Reference Secret Values
+
+Reference individual keys from the Secret:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: my-mcp-server
+spec:
+  image: "myregistry/mcp-server:latest"
+
+  environment:
+    - name: API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: mcp-server-secrets
+          key: api-key
+    - name: DB_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: mcp-server-secrets
+          key: db-password
+    - name: OAUTH_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: mcp-server-secrets
+          key: oauth-token
+```
+
+### Optional References
+
+Make references optional (pod starts even if key is missing):
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: my-mcp-server
+spec:
+  image: "myregistry/mcp-server:latest"
+
+  environment:
+    - name: OPTIONAL_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: mcp-server-secrets
+          key: optional-api-key
+          optional: true
+```
+
+## Volume Mounts for Configuration Files
+
+For complex configurations or when your application expects configuration files, use volume mounts.
+
+### ConfigMap as Volume
+
+Mount an entire ConfigMap as files:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-server-files
+data:
+  config.json: |
+    {
+      "server": {
+        "host": "0.0.0.0",
+        "port": 8080
+      },
+      "logging": {
+        "level": "info"
+      }
+    }
+  rules.yaml: |
+    rules:
+      - name: rule1
+        enabled: true
+---
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: my-mcp-server
+spec:
+  image: "myregistry/mcp-server:latest"
+
+  # Point to the config file location
+  environment:
+    - name: CONFIG_FILE
+      value: "/etc/mcp/config/config.json"
+
+  podTemplate:
+    volumes:
+      - name: config-volume
+        configMap:
+          name: mcp-server-files
+
+    volumeMounts:
+      - name: config-volume
+        mountPath: /etc/mcp/config
+        readOnly: true
+```
+
+### Secret as Volume
+
+Mount sensitive configuration files:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mcp-server-certs
+type: Opaque
+stringData:
+  tls.crt: |
+    -----BEGIN CERTIFICATE-----
+    ...
+    -----END CERTIFICATE-----
+  tls.key: |
+    -----BEGIN PRIVATE KEY-----
+    ...
+    -----END PRIVATE KEY-----
+---
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: my-mcp-server
+spec:
+  image: "myregistry/mcp-server:latest"
+
+  environment:
+    - name: TLS_CERT_PATH
+      value: "/etc/mcp/certs/tls.crt"
+    - name: TLS_KEY_PATH
+      value: "/etc/mcp/certs/tls.key"
+
+  podTemplate:
+    volumes:
+      - name: certs-volume
+        secret:
+          secretName: mcp-server-certs
+          defaultMode: 0400  # Read-only for owner
+
+    volumeMounts:
+      - name: certs-volume
+        mountPath: /etc/mcp/certs
+        readOnly: true
+```
+
+### Specific File from ConfigMap/Secret
+
+Mount only specific keys as files:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: my-mcp-server
+spec:
+  image: "myregistry/mcp-server:latest"
+
+  podTemplate:
+    volumes:
+      - name: config-volume
+        configMap:
+          name: mcp-server-files
+          items:
+            - key: config.json
+              path: config.json
+
+    volumeMounts:
+      - name: config-volume
+        mountPath: /etc/mcp/config
+        readOnly: true
+```
+
+## Common Environment Variables
+
+While environment variables are application-specific, here are common patterns for MCP servers:
+
+### Server Configuration
+
+```yaml
+environment:
+  # Server binding
+  - name: MCP_HOST
+    value: "0.0.0.0"
+  - name: MCP_PORT
+    value: "8080"
+
+  # Transport configuration
+  - name: MCP_TRANSPORT
+    value: "sse"  # or "streamable-http"
+  - name: MCP_PATH
+    value: "/mcp"
+```
+
+### Logging
+
+```yaml
+environment:
+  # Log level
+  - name: LOG_LEVEL
+    value: "info"  # debug, info, warn, error
+
+  # Log format
+  - name: LOG_FORMAT
+    value: "json"  # json, text
+
+  # Log output
+  - name: LOG_OUTPUT
+    value: "stdout"
+```
+
+### Feature Flags
+
+```yaml
+environment:
+  # Enable/disable features
+  - name: ENABLE_METRICS
+    value: "true"
+  - name: ENABLE_TRACING
+    value: "false"
+  - name: ENABLE_CACHING
+    value: "true"
+
+  # Feature configuration
+  - name: CACHE_TTL
+    value: "3600"
+  - name: MAX_CACHE_SIZE
+    value: "1000"
+```
+
+### Performance Tuning
+
+```yaml
+environment:
+  # Connection limits
+  - name: MAX_CONNECTIONS
+    value: "100"
+  - name: CONNECTION_TIMEOUT
+    value: "30s"
+
+  # Worker configuration
+  - name: WORKER_THREADS
+    value: "4"
+  - name: QUEUE_SIZE
+    value: "1000"
+```
+
+### Environment Identification
+
+```yaml
+environment:
+  # Environment type
+  - name: ENVIRONMENT
+    value: "production"  # development, staging, production
+
+  # Deployment metadata
+  - name: VERSION
+    value: "1.0.0"
+  - name: BUILD_ID
+    value: "abc123"
+  - name: DEPLOYMENT_ID
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+```
+
+## Best Practices
+
+### 1. Use Secrets for Sensitive Data
+
+Always use Secrets for sensitive information:
+
+```yaml
+# ✅ Good - Using Secret
+environment:
+  - name: API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: mcp-secrets
+        key: api-key
+
+# ❌ Bad - Plaintext sensitive data
+environment:
+  - name: API_KEY
+    value: "super-secret-key"
+```
+
+### 2. Separate Configuration by Environment
+
+Create separate ConfigMaps for different environments:
+
+```bash
+# Development
+kubectl create configmap mcp-config-dev \
+  --from-literal=log_level=debug \
+  --from-literal=cache_enabled=false
+
+# Production
+kubectl create configmap mcp-config-prod \
+  --from-literal=log_level=warn \
+  --from-literal=cache_enabled=true
+```
+
+Then reference the appropriate ConfigMap in each environment.
+
+### 3. Use Descriptive Names
+
+Choose clear, descriptive environment variable names:
+
+```yaml
+# ✅ Good
+environment:
+  - name: DATABASE_CONNECTION_TIMEOUT_SECONDS
+    value: "30"
+
+# ❌ Less clear
+environment:
+  - name: DB_TIMEOUT
+    value: "30"
+```
+
+### 4. Document Required Variables
+
+Document which environment variables are required vs. optional in your application documentation.
+
+### 5. Validate Configuration
+
+Have your application validate configuration on startup and fail fast if required variables are missing or invalid.
+
+### 6. Use Read-Only Mounts
+
+Mount configuration volumes as read-only when possible:
+
+```yaml
+podTemplate:
+  volumeMounts:
+    - name: config-volume
+      mountPath: /etc/mcp/config
+      readOnly: true  # ✅ Prevents accidental modification
+```
+
+### 7. Avoid Hardcoding Defaults
+
+Let your application handle defaults rather than setting them all in the MCPServer spec:
+
+```yaml
+# ✅ Good - Only override what's necessary
+environment:
+  - name: LOG_LEVEL
+    value: "info"
+
+# ❌ Unnecessary - Let app use its defaults
+environment:
+  - name: LOG_LEVEL
+    value: "info"
+  - name: LOG_FORMAT
+    value: "json"
+  - name: LOG_COLOR
+    value: "false"
+  - name: LOG_TIMESTAMPS
+    value: "true"
+```
+
+### 8. Use Namespaces for Organization
+
+Organize resources by namespace:
+
+```bash
+# Create namespace
+kubectl create namespace mcp-production
+
+# Create ConfigMap in namespace
+kubectl create configmap mcp-config \
+  --namespace mcp-production \
+  --from-literal=log_level=info
+
+# Reference in MCPServer (in same namespace)
+```
+
+## Troubleshooting
+
+### Environment Variable Not Set
+
+**Symptom:** Application can't find expected environment variable.
+
+**Check if the variable is defined:**
+
+```bash
+kubectl get mcpserver my-mcp-server -o jsonpath='{.spec.environment}'
+```
+
+**Check the actual pod environment:**
+
+```bash
+# Get pod name
+POD_NAME=$(kubectl get pods -l app.kubernetes.io/instance=my-mcp-server -o jsonpath='{.items[0].metadata.name}')
+
+# Check environment variables
+kubectl exec $POD_NAME -- env | grep MY_VAR
+```
+
+### ConfigMap/Secret Not Found
+
+**Symptom:** Pod fails to start with error about missing ConfigMap or Secret.
+
+**Verify the resource exists:**
+
+```bash
+kubectl get configmap mcp-server-config
+kubectl get secret mcp-server-secrets
+```
+
+**Check the namespace:**
+
+```bash
+# Resources must be in the same namespace as MCPServer
+kubectl get configmap mcp-server-config -n my-namespace
+```
+
+**Solution:** Create the missing resource or fix the name reference.
+
+### Wrong ConfigMap/Secret Key
+
+**Symptom:** Pod fails to start or variable has wrong value.
+
+**Check available keys:**
+
+```bash
+# ConfigMap
+kubectl describe configmap mcp-server-config
+
+# Secret
+kubectl describe secret mcp-server-secrets
+kubectl get secret mcp-server-secrets -o jsonpath='{.data}' | jq
+```
+
+**Solution:** Use the correct key name in your `configMapKeyRef` or `secretKeyRef`.
+
+### Volume Mount Issues
+
+**Symptom:** Application can't read configuration file.
+
+**Check if volume is mounted:**
+
+```bash
+# Describe the pod
+POD_NAME=$(kubectl get pods -l app.kubernetes.io/instance=my-mcp-server -o jsonpath='{.items[0].metadata.name}')
+kubectl describe pod $POD_NAME
+
+# Check mounts
+kubectl exec $POD_NAME -- ls -la /etc/mcp/config
+```
+
+**Check file permissions:**
+
+```bash
+# If using read-only root filesystem
+kubectl exec $POD_NAME -- ls -la /etc/mcp/config
+```
+
+**Solution:** Verify volume and volumeMount configuration, check that paths match, and ensure proper permissions.
+
+### Changes Not Reflected
+
+**Symptom:** Updated ConfigMap or Secret but pod still has old values.
+
+**Why:** Pods don't automatically restart when ConfigMap/Secret changes.
+
+**Solutions:**
+
+1. **Manually restart pods:**
+   ```bash
+   kubectl rollout restart deployment -l app.kubernetes.io/instance=my-mcp-server
+   ```
+
+2. **Update MCPServer spec to trigger recreation:**
+   ```bash
+   kubectl patch mcpserver my-mcp-server --type='json' \
+     -p='[{"op": "add", "path": "/spec/podTemplate/annotations/restartedAt", "value":"'$(date +%s)'"}]'
+   ```
+
+3. **Use a tool like Reloader:** Auto-restarts deployments when ConfigMaps/Secrets change.
+
+### Debugging Environment Variables
+
+**View all environment variables in a running pod:**
+
+```bash
+POD_NAME=$(kubectl get pods -l app.kubernetes.io/instance=my-mcp-server -o jsonpath='{.items[0].metadata.name}')
+kubectl exec $POD_NAME -- env | sort
+```
+
+**Check logs for configuration errors:**
+
+```bash
+kubectl logs $POD_NAME | grep -i "config\|environment\|variable"
+```
+
+**Test with a different value:**
+
+```bash
+# Temporarily update MCPServer
+kubectl edit mcpserver my-mcp-server
+
+# Or patch it
+kubectl patch mcpserver my-mcp-server --type='json' \
+  -p='[{"op": "replace", "path": "/spec/environment/0/value", "value":"debug"}]'
+```
+
+## See Also
+
+- [API Reference](api-reference.md) - Complete field documentation
+- [Configuration Guide](configuration-guide.md) - Configuration patterns and examples
+- [Troubleshooting Guide](troubleshooting.md) - Common issues and solutions
+- [Kubernetes ConfigMaps](https://kubernetes.io/docs/concepts/configuration/configmap/)
+- [Kubernetes Secrets](https://kubernetes.io/docs/concepts/configuration/secret/)

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,618 @@
+# Monitoring Guide
+
+Complete guide to monitoring MCP servers with Prometheus metrics and Grafana dashboards.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [Available Metrics](#available-metrics)
+- [Grafana Dashboard](#grafana-dashboard)
+- [Recommended Alerts](#recommended-alerts)
+- [Query Examples](#query-examples)
+- [Troubleshooting](#troubleshooting)
+
+## Overview
+
+The MCP Operator exposes Prometheus metrics for monitoring server health, performance, and protocol validation. An optional Grafana dashboard provides visualization of these metrics.
+
+**Key Features:**
+- Real-time server health tracking
+- Phase distribution monitoring
+- Validation compliance tracking
+- Replica count monitoring by transport type
+- Reconciliation performance metrics
+
+## Prerequisites
+
+Before installing monitoring, you need:
+
+### 1. Prometheus Operator
+
+The monitoring stack requires [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) to be installed in your cluster.
+
+**Check if Prometheus Operator is installed:**
+
+```bash
+kubectl get crd prometheuses.monitoring.coreos.com
+kubectl get crd servicemonitors.monitoring.coreos.com
+```
+
+If these CRDs exist, you have Prometheus Operator installed.
+
+**Install Prometheus Operator (if needed):**
+
+Using Helm:
+
+```bash
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+helm install prometheus prometheus-community/kube-prometheus-stack \
+  --namespace monitoring \
+  --create-namespace
+```
+
+Or using kube-prometheus:
+
+```bash
+git clone https://github.com/prometheus-operator/kube-prometheus.git
+cd kube-prometheus
+kubectl apply --server-side -f manifests/setup
+kubectl wait --for condition=Established --all CustomResourceDefinition --namespace=monitoring
+kubectl apply -f manifests/
+```
+
+### 2. Grafana (Optional)
+
+If you installed Prometheus Operator with kube-prometheus-stack, Grafana is included. Otherwise, install it:
+
+```bash
+helm install grafana grafana/grafana \
+  --namespace monitoring \
+  --set adminPassword=admin
+```
+
+## Installation
+
+Once Prometheus Operator is installed, deploy the monitoring manifests:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/vitorbari/mcp-operator/main/dist/monitoring.yaml
+```
+
+This creates:
+- **ServiceMonitor** - Tells Prometheus to scrape operator metrics
+- **Grafana Dashboard** - Pre-built dashboard ConfigMap
+
+### Verify Installation
+
+Check that the ServiceMonitor was created:
+
+```bash
+kubectl get servicemonitor -n mcp-operator-system
+```
+
+Expected output:
+
+```
+NAME                              AGE
+mcp-operator-controller-manager   30s
+```
+
+Verify Prometheus is scraping metrics:
+
+```bash
+# Port forward to Prometheus
+kubectl port-forward -n monitoring svc/prometheus-operated 9090:9090
+
+# Open http://localhost:9090 in browser
+# Go to Status → Targets
+# Look for "mcp-operator-system/mcp-operator-controller-manager"
+```
+
+## Available Metrics
+
+### mcpserver_ready_total
+
+**Type:** Gauge
+
+**Description:** Number of ready MCPServer instances.
+
+**Labels:**
+- `name` - MCPServer name
+- `namespace` - MCPServer namespace
+
+**Example:**
+
+```promql
+mcpserver_ready_total{name="my-mcp-server",namespace="default"}
+```
+
+**Usage:** Track which servers are ready and serving traffic.
+
+### mcpserver_phase
+
+**Type:** Gauge
+
+**Description:** Current phase of MCPServer instances (1 = in this phase, 0 = not in this phase).
+
+**Labels:**
+- `name` - MCPServer name
+- `namespace` - MCPServer namespace
+- `phase` - Phase name (Creating, Running, Scaling, Failed, ValidationFailed, Terminating)
+
+**Example:**
+
+```promql
+mcpserver_phase{name="my-mcp-server",namespace="default",phase="Running"}
+```
+
+**Usage:** Monitor server lifecycle phases and detect issues.
+
+### mcpserver_validation_compliant
+
+**Type:** Gauge
+
+**Description:** Whether MCPServer passed validation (1 = compliant, 0 = not compliant).
+
+**Labels:**
+- `name` - MCPServer name
+- `namespace` - MCPServer namespace
+
+**Example:**
+
+```promql
+mcpserver_validation_compliant{name="my-mcp-server",namespace="default"}
+```
+
+**Usage:** Track protocol compliance across servers.
+
+### mcpserver_replicas
+
+**Type:** Gauge
+
+**Description:** Number of replicas for MCPServer instances.
+
+**Labels:**
+- `name` - MCPServer name
+- `namespace` - MCPServer namespace
+- `transport_type` - Transport type (http, custom)
+- `type` - Replica type (desired, current, ready, available)
+
+**Example:**
+
+```promql
+mcpserver_replicas{name="my-mcp-server",namespace="default",transport_type="http",type="ready"}
+```
+
+**Usage:** Monitor replica counts and scaling behavior.
+
+### mcpserver_reconcile_duration_seconds
+
+**Type:** Histogram
+
+**Description:** Time taken to reconcile MCPServer resources.
+
+**Labels:**
+- `name` - MCPServer name
+- `namespace` - MCPServer namespace
+
+**Buckets:** 0.01, 0.05, 0.1, 0.5, 1, 5, 10, 30
+
+**Example:**
+
+```promql
+histogram_quantile(0.95, rate(mcpserver_reconcile_duration_seconds_bucket[5m]))
+```
+
+**Usage:** Track operator performance and identify slow reconciliation loops.
+
+## Grafana Dashboard
+
+### Accessing the Dashboard
+
+If you used kube-prometheus-stack, access Grafana:
+
+```bash
+# Get Grafana admin password
+kubectl get secret -n monitoring prometheus-grafana -o jsonpath="{.data.admin-password}" | base64 --decode
+
+# Port forward to Grafana
+kubectl port-forward -n monitoring svc/prometheus-grafana 3000:80
+```
+
+Open http://localhost:3000 in your browser and log in with:
+- Username: `admin`
+- Password: (from command above)
+
+### Installing the Dashboard
+
+The dashboard is automatically created as a ConfigMap. Import it into Grafana:
+
+**Method 1: Automatic (if using Grafana sidecar)**
+
+The dashboard should appear automatically under "Dashboards → Browse → MCP Operator".
+
+**Method 2: Manual Import**
+
+1. Extract the dashboard JSON:
+   ```bash
+   kubectl get configmap mcp-operator-dashboard -n mcp-operator-system -o jsonpath='{.data.mcp-operator-dashboard\.json}' > dashboard.json
+   ```
+
+2. In Grafana:
+   - Click "+" → "Import"
+   - Upload `dashboard.json`
+   - Select Prometheus data source
+   - Click "Import"
+
+### Dashboard Panels
+
+The dashboard includes:
+
+#### 1. Overview
+
+- **Total MCPServers** - Count of all MCPServer resources
+- **Ready Servers** - Servers currently ready
+- **Validation Compliance Rate** - Percentage of compliant servers
+- **Average Replicas** - Average replica count across servers
+
+#### 2. Server Status
+
+- **MCPServer Phase Distribution** - Pie chart showing phase breakdown
+- **Server Ready Status** - Table of all servers with ready status
+- **Validation State** - Validation status by server
+
+#### 3. Protocol Intelligence
+
+- **Transport Type Distribution** - Breakdown by transport type (HTTP, custom)
+- **Protocol Version Distribution** - MCP protocol versions in use
+- **Validation Compliance Over Time** - Time series of compliance rate
+
+#### 4. Performance
+
+- **Reconciliation Duration (p95)** - 95th percentile reconciliation time
+- **Reconciliation Rate** - Reconciliations per second
+- **Slow Reconciliations** - Servers with slow reconciliation loops
+
+#### 5. Scaling
+
+- **Replica Count by Server** - Current vs desired replicas
+- **Replica Changes Over Time** - Scaling activity
+- **HPA Status** - Autoscaling behavior
+
+## Recommended Alerts
+
+Configure Prometheus alerts to catch issues early.
+
+### Creating Alert Rules
+
+Create a PrometheusRule resource:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: mcp-operator-alerts
+  namespace: mcp-operator-system
+  labels:
+    prometheus: kube-prometheus
+spec:
+  groups:
+    - name: mcp-operator
+      interval: 30s
+      rules:
+        # MCPServer not ready
+        - alert: MCPServerNotReady
+          expr: mcpserver_ready_total == 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "MCPServer {{ $labels.name }} not ready"
+            description: "MCPServer {{ $labels.name }} in namespace {{ $labels.namespace }} has been not ready for 5 minutes."
+
+        # MCPServer in Failed phase
+        - alert: MCPServerFailed
+          expr: mcpserver_phase{phase="Failed"} == 1
+          for: 2m
+          labels:
+            severity: critical
+          annotations:
+            summary: "MCPServer {{ $labels.name }} in Failed state"
+            description: "MCPServer {{ $labels.name }} in namespace {{ $labels.namespace }} is in Failed phase."
+
+        # Validation failed
+        - alert: MCPServerValidationFailed
+          expr: mcpserver_validation_compliant == 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "MCPServer {{ $labels.name }} validation failed"
+            description: "MCPServer {{ $labels.name }} in namespace {{ $labels.namespace }} is not MCP compliant."
+
+        # High reconciliation duration
+        - alert: MCPServerSlowReconciliation
+          expr: histogram_quantile(0.95, rate(mcpserver_reconcile_duration_seconds_bucket[5m])) > 10
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Slow reconciliation for {{ $labels.name }}"
+            description: "MCPServer {{ $labels.name }} reconciliation is taking over 10 seconds (p95)."
+
+        # Replica count mismatch
+        - alert: MCPServerReplicaMismatch
+          expr: |
+            (mcpserver_replicas{type="desired"} - mcpserver_replicas{type="ready"}) > 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Replica mismatch for {{ $labels.name }}"
+            description: "MCPServer {{ $labels.name }} has {{ $value }} fewer ready replicas than desired for 15 minutes."
+
+        # No ready replicas
+        - alert: MCPServerNoReplicas
+          expr: mcpserver_replicas{type="ready"} == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "No ready replicas for {{ $labels.name }}"
+            description: "MCPServer {{ $labels.name }} has no ready replicas."
+```
+
+Apply the alert rules:
+
+```bash
+kubectl apply -f alerts.yaml
+```
+
+### Viewing Alerts
+
+In Prometheus UI (http://localhost:9090):
+- Go to "Alerts" to see configured alerts
+- Active alerts will show current status
+
+In Grafana:
+- Go to "Alerting → Alert rules"
+- Configure notification channels (email, Slack, PagerDuty, etc.)
+
+## Query Examples
+
+### Basic Queries
+
+**List all MCPServers and their ready status:**
+
+```promql
+mcpserver_ready_total
+```
+
+**Count servers by phase:**
+
+```promql
+count by (phase) (mcpserver_phase == 1)
+```
+
+**Total ready replicas across all servers:**
+
+```promql
+sum(mcpserver_replicas{type="ready"})
+```
+
+### Advanced Queries
+
+**Servers with replica count mismatch:**
+
+```promql
+(
+  mcpserver_replicas{type="desired"}
+  - on(name, namespace) group_left()
+  mcpserver_replicas{type="ready"}
+) > 0
+```
+
+**Average reconciliation duration by server:**
+
+```promql
+rate(mcpserver_reconcile_duration_seconds_sum[5m])
+/ rate(mcpserver_reconcile_duration_seconds_count[5m])
+```
+
+**Validation compliance rate (percentage):**
+
+```promql
+100 * sum(mcpserver_validation_compliant) / count(mcpserver_validation_compliant)
+```
+
+**Servers with most replica changes (churn):**
+
+```promql
+delta(mcpserver_replicas{type="ready"}[1h])
+```
+
+**Transport type distribution:**
+
+```promql
+count by (transport_type) (mcpserver_replicas{type="current"})
+```
+
+### Performance Queries
+
+**95th percentile reconciliation time:**
+
+```promql
+histogram_quantile(0.95, rate(mcpserver_reconcile_duration_seconds_bucket[5m]))
+```
+
+**Reconciliation rate (per second):**
+
+```promql
+rate(mcpserver_reconcile_duration_seconds_count[5m])
+```
+
+**Slowest servers (p99 reconciliation time):**
+
+```promql
+topk(5,
+  histogram_quantile(0.99,
+    rate(mcpserver_reconcile_duration_seconds_bucket[5m])
+  )
+)
+```
+
+### Alerting Queries
+
+**Servers stuck in Creating phase for >10 minutes:**
+
+```promql
+mcpserver_phase{phase="Creating"} == 1
+and time() - mcpserver_phase{phase="Creating"} > 600
+```
+
+**Servers with validation issues:**
+
+```promql
+mcpserver_phase{phase="ValidationFailed"} == 1
+or mcpserver_validation_compliant == 0
+```
+
+## Troubleshooting
+
+### Metrics Not Appearing
+
+**Check ServiceMonitor:**
+
+```bash
+kubectl get servicemonitor -n mcp-operator-system
+kubectl describe servicemonitor mcp-operator-controller-manager -n mcp-operator-system
+```
+
+**Verify labels match:**
+
+The ServiceMonitor should match the operator service labels:
+
+```bash
+kubectl get svc -n mcp-operator-system mcp-operator-controller-manager-metrics-service -o yaml
+```
+
+**Check Prometheus targets:**
+
+```bash
+# Port forward to Prometheus
+kubectl port-forward -n monitoring svc/prometheus-operated 9090:9090
+
+# Visit http://localhost:9090/targets
+# Look for mcp-operator-controller-manager target
+```
+
+**Check Prometheus operator logs:**
+
+```bash
+kubectl logs -n monitoring -l app.kubernetes.io/name=prometheus-operator
+```
+
+### Dashboard Not Loading
+
+**Verify ConfigMap exists:**
+
+```bash
+kubectl get configmap mcp-operator-dashboard -n mcp-operator-system
+```
+
+**Check Grafana sidecar labels:**
+
+If using automatic dashboard loading, verify the ConfigMap has the right labels:
+
+```bash
+kubectl get configmap mcp-operator-dashboard -n mcp-operator-system -o yaml
+```
+
+Should have labels like:
+
+```yaml
+labels:
+  grafana_dashboard: "1"
+```
+
+**Manual import:**
+
+Extract and manually import the dashboard (see [Installing the Dashboard](#installing-the-dashboard)).
+
+### Missing Data Points
+
+**Check metric endpoints:**
+
+```bash
+# Port forward to operator metrics
+kubectl port-forward -n mcp-operator-system \
+  svc/mcp-operator-controller-manager-metrics-service 8443:8443
+
+# Query metrics (if HTTPS)
+curl -k https://localhost:8443/metrics
+
+# Or if HTTP
+curl http://localhost:8443/metrics
+```
+
+**Verify MCPServers exist:**
+
+Metrics are only generated for existing MCPServer resources:
+
+```bash
+kubectl get mcpservers --all-namespaces
+```
+
+**Check scrape interval:**
+
+Metrics update based on Prometheus scrape interval (default: 30s). Wait a minute for data to appear.
+
+### High Cardinality Warnings
+
+**Symptom:** Prometheus warns about high cardinality metrics.
+
+**Cause:** Too many unique label combinations (e.g., many MCPServer instances).
+
+**Solution:** This is expected for large deployments. Consider:
+- Increasing Prometheus resources
+- Reducing metric retention period
+- Using recording rules to pre-aggregate metrics
+
+### Permission Errors
+
+**Symptom:** ServiceMonitor created but Prometheus can't scrape.
+
+**Check RBAC:**
+
+```bash
+kubectl get clusterrole prometheus-k8s -o yaml
+```
+
+Verify it has permissions to get/list/watch services and endpoints in `mcp-operator-system` namespace.
+
+**Solution:** Update Prometheus RBAC if needed:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-k8s
+rules:
+  - apiGroups: [""]
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list", "watch"]
+```
+
+## See Also
+
+- [Configuration Guide](configuration-guide.md) - Configure your MCP servers
+- [Troubleshooting Guide](troubleshooting.md) - Common issues and solutions
+- [API Reference](api-reference.md) - Complete CRD documentation
+- [Prometheus Operator Documentation](https://prometheus-operator.dev/)
+- [Grafana Documentation](https://grafana.com/docs/)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,978 @@
+# Troubleshooting Guide
+
+Common issues and solutions for the MCP Operator.
+
+## Table of Contents
+
+- [Quick Diagnostics](#quick-diagnostics)
+- [Installation Issues](#installation-issues)
+- [Deployment Issues](#deployment-issues)
+- [Validation Issues](#validation-issues)
+- [Scaling Issues](#scaling-issues)
+- [Resource Issues](#resource-issues)
+- [Configuration Issues](#configuration-issues)
+- [Networking Issues](#networking-issues)
+- [Debug Mode](#debug-mode)
+- [Getting Help](#getting-help)
+
+## Quick Diagnostics
+
+Before diving into specific issues, run these commands to gather information:
+
+### Check MCPServer Status
+
+```bash
+# List all MCPServers
+kubectl get mcpservers --all-namespaces
+
+# Get detailed status
+kubectl get mcpserver <name> -o yaml
+
+# Watch status changes in real-time
+kubectl get mcpservers -w
+```
+
+### Check Pods
+
+```bash
+# List pods for your MCPServer
+kubectl get pods -l app.kubernetes.io/instance=<mcpserver-name>
+
+# Describe pod for events
+kubectl describe pod <pod-name>
+
+# Check pod logs
+kubectl logs <pod-name>
+
+# Check previous pod logs (if pod restarted)
+kubectl logs <pod-name> --previous
+```
+
+### Check Validation Status
+
+```bash
+# Get validation details
+kubectl get mcpserver <name> -o jsonpath='{.status.validation}' | jq
+
+# Check for validation issues
+kubectl get mcpserver <name> -o jsonpath='{.status.validation.issues}' | jq
+```
+
+### Check Operator Logs
+
+```bash
+# Get operator pod name
+OPERATOR_POD=$(kubectl get pods -n mcp-operator-system -l control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}')
+
+# View operator logs
+kubectl logs -n mcp-operator-system $OPERATOR_POD -c manager
+
+# Follow logs in real-time
+kubectl logs -n mcp-operator-system $OPERATOR_POD -c manager -f
+```
+
+## Installation Issues
+
+### Operator Not Installing
+
+**Symptom:** Installation command fails or operator pod doesn't start.
+
+**Check installation:**
+
+```bash
+kubectl get pods -n mcp-operator-system
+kubectl get deployment -n mcp-operator-system
+```
+
+**Common causes:**
+
+1. **Network issues downloading manifests**
+
+   ```bash
+   # Download manifest first
+   curl -O https://raw.githubusercontent.com/vitorbari/mcp-operator/main/dist/install.yaml
+
+   # Inspect and apply
+   kubectl apply -f install.yaml
+   ```
+
+2. **Insufficient permissions**
+
+   ```bash
+   # Check if you can create namespaces
+   kubectl auth can-i create namespaces
+
+   # Check if you can create CRDs
+   kubectl auth can-i create customresourcedefinitions
+   ```
+
+3. **Resource constraints**
+
+   ```bash
+   # Check node resources
+   kubectl top nodes
+
+   # Check if pods are pending
+   kubectl get pods -n mcp-operator-system
+   kubectl describe pod <operator-pod-name> -n mcp-operator-system
+   ```
+
+**Solution:**
+
+```bash
+# Ensure you have cluster-admin permissions
+# Or ask your cluster administrator to install the operator
+
+# Verify installation completed
+kubectl wait --for=condition=available --timeout=300s \
+  deployment/mcp-operator-controller-manager \
+  -n mcp-operator-system
+```
+
+### CRDs Not Being Created
+
+**Symptom:** MCPServer resources not recognized.
+
+**Check CRDs:**
+
+```bash
+kubectl get crd mcpservers.mcp.mcp-operator.io
+```
+
+**If CRD doesn't exist:**
+
+```bash
+# Reapply installation manifest
+kubectl apply -f https://raw.githubusercontent.com/vitorbari/mcp-operator/main/dist/install.yaml
+
+# Or install CRDs separately
+kubectl apply -f https://raw.githubusercontent.com/vitorbari/mcp-operator/main/config/crd/bases/mcp.mcp-operator.io_mcpservers.yaml
+```
+
+### Operator Crashing
+
+**Symptom:** Operator pod in CrashLoopBackOff.
+
+**Check logs:**
+
+```bash
+kubectl logs -n mcp-operator-system \
+  deployment/mcp-operator-controller-manager \
+  -c manager
+```
+
+**Common causes:**
+
+1. **Certificate issues** - Webhook certificates not configured
+2. **RBAC issues** - Missing permissions
+3. **Resource limits** - Operator OOMKilled
+
+**Solution:**
+
+```bash
+# Check events
+kubectl describe deployment -n mcp-operator-system mcp-operator-controller-manager
+
+# Verify RBAC
+kubectl get clusterrole mcp-operator-manager-role
+kubectl get clusterrolebinding mcp-operator-manager-rolebinding
+```
+
+## Deployment Issues
+
+### Server Stuck in "Creating" Phase
+
+**Symptom:** MCPServer phase stays "Creating" for a long time.
+
+**Check pod status:**
+
+```bash
+kubectl get pods -l app.kubernetes.io/instance=<mcpserver-name>
+kubectl describe pod <pod-name>
+```
+
+**Common causes:**
+
+#### 1. Image Pull Errors
+
+```bash
+# Look for ImagePullBackOff or ErrImagePull
+kubectl get pods -l app.kubernetes.io/instance=<mcpserver-name>
+```
+
+**Solutions:**
+
+```bash
+# Verify image exists
+docker pull <image-name>
+
+# Check image pull secrets
+kubectl get mcpserver <name> -o jsonpath='{.spec.podTemplate.imagePullSecrets}'
+
+# Create image pull secret if needed
+kubectl create secret docker-registry registry-credentials \
+  --docker-server=<registry-url> \
+  --docker-username=<username> \
+  --docker-password=<password>
+```
+
+#### 2. Insufficient Resources
+
+```bash
+# Check if pod is pending
+kubectl get pods -l app.kubernetes.io/instance=<mcpserver-name>
+
+# Check events
+kubectl describe pod <pod-name> | grep -A 5 Events
+```
+
+**Solution:**
+
+```yaml
+# Reduce resource requests
+spec:
+  resources:
+    requests:
+      cpu: "100m"      # Reduced from 200m
+      memory: "128Mi"  # Reduced from 256Mi
+```
+
+#### 3. Node Selector/Affinity Issues
+
+```bash
+# Check if nodes match selectors
+kubectl get nodes --show-labels
+
+# Check pod events
+kubectl describe pod <pod-name>
+```
+
+**Solution:**
+
+```bash
+# Remove or update node selectors
+kubectl edit mcpserver <name>
+
+# Or label nodes to match
+kubectl label nodes <node-name> disktype=ssd
+```
+
+#### 4. Container Crash Loop
+
+```bash
+# Check container logs
+kubectl logs <pod-name>
+
+# Check previous logs if pod restarted
+kubectl logs <pod-name> --previous
+```
+
+**Solution:** Fix application issues preventing startup.
+
+### Server in "Failed" Phase
+
+**Symptom:** MCPServer phase is "Failed".
+
+**Check status message:**
+
+```bash
+kubectl get mcpserver <name> -o jsonpath='{.status.message}'
+```
+
+**Check operator logs:**
+
+```bash
+kubectl logs -n mcp-operator-system \
+  deployment/mcp-operator-controller-manager \
+  -c manager | grep <mcpserver-name>
+```
+
+**Common causes:**
+
+1. **Deployment creation failed**
+2. **Service creation failed**
+3. **RBAC issues**
+4. **Validation failed in strict mode**
+
+**Solution:**
+
+```bash
+# Check events
+kubectl get events --field-selector involvedObject.name=<mcpserver-name>
+
+# Fix underlying issue and update MCPServer
+kubectl edit mcpserver <name>
+```
+
+### Server Running but Not Accessible
+
+**Symptom:** Pods are running but service doesn't respond.
+
+**Check service:**
+
+```bash
+kubectl get svc <mcpserver-name>
+kubectl describe svc <mcpserver-name>
+```
+
+**Test connectivity:**
+
+```bash
+# From within cluster
+kubectl run -it --rm debug --image=busybox --restart=Never -- \
+  wget -O- http://<mcpserver-name>:8080/mcp
+
+# Port forward to test locally
+kubectl port-forward svc/<mcpserver-name> 8080:8080
+
+# Test: curl http://localhost:8080/mcp
+```
+
+**Common causes:**
+
+#### 1. Wrong Port Configuration
+
+```bash
+# Check service ports
+kubectl get svc <mcpserver-name> -o jsonpath='{.spec.ports}'
+
+# Check container port
+kubectl get pod <pod-name> -o jsonpath='{.spec.containers[0].ports}'
+```
+
+**Solution:**
+
+```yaml
+spec:
+  transport:
+    config:
+      http:
+        port: 8080  # Must match what server listens on
+  service:
+    port: 8080
+    targetPort: 8080
+```
+
+#### 2. Health Check Failing
+
+```bash
+# Check pod readiness
+kubectl get pods -l app.kubernetes.io/instance=<mcpserver-name>
+
+# Check readiness probe
+kubectl describe pod <pod-name> | grep -A 5 Readiness
+```
+
+**Solution:**
+
+```yaml
+spec:
+  healthCheck:
+    enabled: true
+    path: "/health"  # Ensure this endpoint exists
+    port: 8080
+```
+
+#### 3. Network Policy Blocking Traffic
+
+```bash
+# Check network policies
+kubectl get networkpolicy
+kubectl describe networkpolicy <policy-name>
+```
+
+**Solution:** Update network policies to allow traffic.
+
+## Validation Issues
+
+### Validation State "AuthRequired"
+
+**Symptom:** Validation status shows `AuthRequired`.
+
+**Meaning:** Server requires authentication but validator doesn't have credentials.
+
+**Check validation status:**
+
+```bash
+kubectl get mcpserver <name> -o jsonpath='{.status.validation}' | jq
+```
+
+**Solutions:**
+
+1. **Disable validation if auth is expected:**
+
+   ```yaml
+   spec:
+     validation:
+       enabled: false
+   ```
+
+2. **Configure auth for validation** (future feature)
+
+3. **Use strict mode to fail if auth required:**
+
+   ```yaml
+   spec:
+     validation:
+       enabled: true
+       strictMode: true
+   ```
+
+### Validation State "Failed"
+
+**Symptom:** Validation status shows `Failed`.
+
+**Check validation issues:**
+
+```bash
+kubectl get mcpserver <name> -o jsonpath='{.status.validation.issues}' | jq
+```
+
+**Common causes:**
+
+#### 1. Wrong Protocol
+
+```yaml
+# Issue: Server uses SSE but spec says streamable-http
+status:
+  validation:
+    issues:
+      - level: error
+        message: "Server does not support streamable-http protocol"
+```
+
+**Solution:**
+
+```yaml
+spec:
+  transport:
+    protocol: auto  # Let operator detect
+    # or
+    protocol: sse  # Explicitly use SSE
+```
+
+#### 2. Wrong Port/Path
+
+**Solution:**
+
+```yaml
+spec:
+  transport:
+    config:
+      http:
+        port: 3001       # Match server's port
+        path: "/sse"     # Match server's path
+```
+
+#### 3. Server Not Ready
+
+**Solution:** Wait for server to fully start, then check validation again:
+
+```bash
+kubectl get mcpserver <name> -w
+```
+
+### Required Capabilities Not Met
+
+**Symptom:** Validation fails because server lacks required capabilities.
+
+**Check capabilities:**
+
+```bash
+kubectl get mcpserver <name> -o jsonpath='{.status.validation.capabilities}'
+```
+
+**Solution:**
+
+```yaml
+spec:
+  validation:
+    requiredCapabilities:
+      - "tools"
+      # Remove capabilities your server doesn't support
+      # - "resources"
+      # - "prompts"
+```
+
+### Strict Mode Failures
+
+**Symptom:** Server immediately goes to "ValidationFailed" phase.
+
+**Check validation:**
+
+```bash
+kubectl get mcpserver <name> -o jsonpath='{.status.validation}' | jq
+```
+
+**Solution:**
+
+1. **Fix validation issues** (see above)
+
+2. **Disable strict mode temporarily:**
+
+   ```yaml
+   spec:
+     validation:
+       strictMode: false  # Allow deployment even if validation fails
+   ```
+
+## Scaling Issues
+
+### HPA Not Working
+
+**Symptom:** Replicas don't scale despite CPU/memory usage.
+
+**Check HPA status:**
+
+```bash
+kubectl get hpa <mcpserver-name>-hpa
+kubectl describe hpa <mcpserver-name>-hpa
+```
+
+**Common causes:**
+
+#### 1. Metrics Server Not Installed
+
+```bash
+# Check if metrics-server is running
+kubectl get deployment metrics-server -n kube-system
+```
+
+**Solution:**
+
+```bash
+# Install metrics-server
+kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
+```
+
+#### 2. No Resource Requests Set
+
+HPA requires resource requests to calculate utilization:
+
+```yaml
+spec:
+  resources:
+    requests:  # Required for HPA
+      cpu: "200m"
+      memory: "256Mi"
+```
+
+#### 3. Metrics Not Available
+
+```bash
+# Check if metrics are available
+kubectl top pods -l app.kubernetes.io/instance=<mcpserver-name>
+```
+
+**Solution:** Wait a few minutes for metrics to be collected.
+
+### Replicas Not Scaling Down
+
+**Symptom:** HPA scales up but never scales down.
+
+**Check scale-down behavior:**
+
+```bash
+kubectl get hpa <mcpserver-name>-hpa -o yaml
+```
+
+**Possible causes:**
+
+1. **Scale-down stabilization window**
+2. **Scale-down policies too conservative**
+
+**Solution:**
+
+```yaml
+spec:
+  hpa:
+    scaleDownBehavior:
+      stabilizationWindowSeconds: 60  # Reduced from 300
+      policies:
+        - type: "Pods"
+          value: 2  # Scale down faster
+          periodSeconds: 30
+```
+
+### Replicas Stuck at Minimum
+
+**Symptom:** HPA stays at minReplicas.
+
+**Check current vs desired:**
+
+```bash
+kubectl get hpa <mcpserver-name>-hpa
+```
+
+**Possible causes:**
+
+1. **CPU/Memory below target** - This is normal, HPA maintains minimum
+2. **Metrics not available**
+
+**Verify metrics:**
+
+```bash
+kubectl top pods -l app.kubernetes.io/instance=<mcpserver-name>
+```
+
+## Resource Issues
+
+### Pods Being OOMKilled
+
+**Symptom:** Pods restart with OOMKilled status.
+
+**Check events:**
+
+```bash
+kubectl describe pod <pod-name> | grep -A 5 "Last State"
+```
+
+**Solution:**
+
+```yaml
+spec:
+  resources:
+    requests:
+      memory: "512Mi"  # Increased
+    limits:
+      memory: "2Gi"    # Increased
+```
+
+**Investigate memory usage:**
+
+```bash
+# Monitor memory in real-time
+kubectl top pods -l app.kubernetes.io/instance=<mcpserver-name>
+
+# Check container memory
+kubectl exec <pod-name> -- cat /sys/fs/cgroup/memory/memory.usage_in_bytes
+```
+
+### CPU Throttling
+
+**Symptom:** Application runs slowly despite CPU limit not being reached.
+
+**Check CPU usage:**
+
+```bash
+kubectl top pods -l app.kubernetes.io/instance=<mcpserver-name>
+```
+
+**Solution:**
+
+```yaml
+spec:
+  resources:
+    limits:
+      cpu: "2000m"  # Increased from 1000m
+```
+
+**Investigate:**
+
+```bash
+# Check CPU throttling stats
+kubectl exec <pod-name> -- cat /sys/fs/cgroup/cpu/cpu.stat
+```
+
+### Disk Pressure
+
+**Symptom:** Pods evicted due to disk pressure.
+
+**Check node condition:**
+
+```bash
+kubectl describe node <node-name> | grep DiskPressure
+```
+
+**Solution:**
+
+1. **Clean up node:**
+
+   ```bash
+   # SSH to node and clean up unused images
+   docker system prune -a
+   ```
+
+2. **Use emptyDir with size limit:**
+
+   ```yaml
+   spec:
+     podTemplate:
+       volumes:
+         - name: tmp
+           emptyDir:
+             sizeLimit: 1Gi
+   ```
+
+## Configuration Issues
+
+### Environment Variables Not Working
+
+**Symptom:** Application can't find expected environment variables.
+
+**Check environment:**
+
+```bash
+POD_NAME=$(kubectl get pods -l app.kubernetes.io/instance=<mcpserver-name> -o jsonpath='{.items[0].metadata.name}')
+kubectl exec $POD_NAME -- env | grep <VAR_NAME>
+```
+
+**Check spec:**
+
+```bash
+kubectl get mcpserver <name> -o jsonpath='{.spec.environment}' | jq
+```
+
+**Solution:** See [Environment Variables Guide](environment-variables.md) for detailed troubleshooting.
+
+### Volume Mounts Failing
+
+**Symptom:** Pod fails to start with volume mount errors.
+
+**Check events:**
+
+```bash
+kubectl describe pod <pod-name> | grep -A 10 Events
+```
+
+**Common causes:**
+
+1. **ConfigMap/Secret doesn't exist**
+
+   ```bash
+   kubectl get configmap <name>
+   kubectl get secret <name>
+   ```
+
+2. **Wrong namespace**
+
+   ```bash
+   # ConfigMap/Secret must be in same namespace as MCPServer
+   kubectl get configmap <name> -n <namespace>
+   ```
+
+3. **Wrong mount path conflicts with read-only root**
+
+   ```yaml
+   spec:
+     security:
+       readOnlyRootFilesystem: true
+     podTemplate:
+       volumeMounts:
+         - name: cache
+           mountPath: /tmp/cache  # Must be writable volume
+   ```
+
+### ConfigMap/Secret Changes Not Reflected
+
+**Symptom:** Updated ConfigMap but pod still has old values.
+
+**Why:** Pods don't automatically restart when ConfigMaps/Secrets change.
+
+**Solution:**
+
+```bash
+# Restart pods to pick up changes
+kubectl rollout restart deployment -l app.kubernetes.io/instance=<mcpserver-name>
+
+# Or trigger update via annotation
+kubectl patch mcpserver <name> --type='json' \
+  -p='[{"op": "add", "path": "/spec/podTemplate/annotations/restartedAt", "value":"'$(date +%s)'"}]'
+```
+
+## Networking Issues
+
+### Service Not Accessible
+
+**Symptom:** Can't reach service from within cluster.
+
+**Test DNS:**
+
+```bash
+kubectl run -it --rm debug --image=busybox --restart=Never -- \
+  nslookup <mcpserver-name>
+```
+
+**Test connectivity:**
+
+```bash
+kubectl run -it --rm debug --image=busybox --restart=Never -- \
+  wget -O- http://<mcpserver-name>:8080/mcp
+```
+
+**Check service endpoints:**
+
+```bash
+kubectl get endpoints <mcpserver-name>
+```
+
+If no endpoints, pods aren't ready or labels don't match.
+
+### Port Conflicts
+
+**Symptom:** Service fails to bind to port.
+
+**Check for conflicts:**
+
+```bash
+kubectl get svc --all-namespaces | grep <port-number>
+```
+
+**Solution:** Use a different port or namespace.
+
+### DNS Resolution Issues
+
+**Symptom:** Can't resolve service name.
+
+**Check CoreDNS:**
+
+```bash
+kubectl get pods -n kube-system -l k8s-app=kube-dns
+```
+
+**Test DNS:**
+
+```bash
+kubectl run -it --rm debug --image=busybox --restart=Never -- \
+  nslookup kubernetes.default
+```
+
+## Debug Mode
+
+### Enable Verbose Logging
+
+**In MCPServer:**
+
+```yaml
+spec:
+  environment:
+    - name: LOG_LEVEL
+      value: "debug"
+```
+
+**In Operator:**
+
+```bash
+# Edit operator deployment
+kubectl edit deployment -n mcp-operator-system mcp-operator-controller-manager
+
+# Add --zap-log-level=debug to manager container args
+```
+
+### Collect Diagnostics
+
+**Gather all relevant information:**
+
+```bash
+#!/bin/bash
+MCPSERVER_NAME="my-mcp-server"
+OUTPUT_DIR="diagnostics-$(date +%Y%m%d-%H%M%S)"
+mkdir -p $OUTPUT_DIR
+
+# MCPServer resource
+kubectl get mcpserver $MCPSERVER_NAME -o yaml > $OUTPUT_DIR/mcpserver.yaml
+
+# Pods
+kubectl get pods -l app.kubernetes.io/instance=$MCPSERVER_NAME -o yaml > $OUTPUT_DIR/pods.yaml
+
+# Pod logs
+for pod in $(kubectl get pods -l app.kubernetes.io/instance=$MCPSERVER_NAME -o jsonpath='{.items[*].metadata.name}'); do
+  kubectl logs $pod > $OUTPUT_DIR/log-$pod.txt 2>&1
+  kubectl logs $pod --previous > $OUTPUT_DIR/log-$pod-previous.txt 2>&1 || true
+done
+
+# Events
+kubectl get events --field-selector involvedObject.name=$MCPSERVER_NAME > $OUTPUT_DIR/events.txt
+
+# Service
+kubectl get svc $MCPSERVER_NAME -o yaml > $OUTPUT_DIR/service.yaml
+
+# Operator logs
+kubectl logs -n mcp-operator-system deployment/mcp-operator-controller-manager -c manager > $OUTPUT_DIR/operator-logs.txt
+
+# Create tarball
+tar czf $OUTPUT_DIR.tar.gz $OUTPUT_DIR
+echo "Diagnostics collected in $OUTPUT_DIR.tar.gz"
+```
+
+### Test Validation Manually
+
+**Port forward to server:**
+
+```bash
+kubectl port-forward svc/<mcpserver-name> 8080:8080
+```
+
+**Test streamable-http:**
+
+```bash
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"initialize","params":{},"id":1}'
+```
+
+**Test SSE:**
+
+```bash
+curl http://localhost:8080/sse
+```
+
+## Getting Help
+
+### Before Asking for Help
+
+1. **Check this troubleshooting guide**
+2. **Search existing GitHub issues**
+3. **Collect diagnostics** (see [Debug Mode](#debug-mode))
+
+### Where to Get Help
+
+**GitHub Issues:** [vitorbari/mcp-operator/issues](https://github.com/vitorbari/mcp-operator/issues)
+
+Use for:
+- Bug reports
+- Feature requests
+- Documentation issues
+
+**GitHub Discussions:** [vitorbari/mcp-operator/discussions](https://github.com/vitorbari/mcp-operator/discussions)
+
+Use for:
+- Questions
+- Ideas
+- General discussion
+
+### What to Include
+
+When opening an issue, include:
+
+1. **Environment:**
+   - Kubernetes version: `kubectl version`
+   - Operator version: `kubectl get deployment -n mcp-operator-system mcp-operator-controller-manager -o jsonpath='{.spec.template.spec.containers[0].image}'`
+   - Cloud provider or bare metal
+
+2. **MCPServer Configuration:**
+   ```bash
+   kubectl get mcpserver <name> -o yaml
+   ```
+
+3. **Current Status:**
+   ```bash
+   kubectl get mcpserver <name> -o jsonpath='{.status}' | jq
+   ```
+
+4. **Logs:**
+   - Pod logs
+   - Operator logs
+   - Relevant events
+
+5. **What you've tried:**
+   - Steps to reproduce
+   - Solutions attempted
+
+## See Also
+
+- [Configuration Guide](configuration-guide.md) - Configuration patterns
+- [Environment Variables Guide](environment-variables.md) - Environment variable configuration
+- [Monitoring Guide](monitoring.md) - Metrics and alerting
+- [Validation Behavior](validation-behavior.md) - Protocol validation details
+- [API Reference](api-reference.md) - Complete field documentation


### PR DESCRIPTION
Simplified README.md from 332 to 252 lines (24% reduction) by moving detailed content into focused documentation files. Created comprehensive guides for API reference, configuration, environment variables, monitoring, and troubleshooting.

Changes:
- Simplified README Protocol Validation section (45 → 7 lines)
- Simplified README Monitoring section (19 → 6 lines)
- Removed API Reference tables from README
- Removed Security section from README
- Added comprehensive Documentation section with categorized links

New documentation files:
- docs/api-reference.md (740 lines) - Complete CRD field reference
- docs/environment-variables.md (562 lines) - Env var configuration guide
- docs/configuration-guide.md (829 lines) - Configuration patterns & examples
- docs/monitoring.md (542 lines) - Metrics, dashboards, and alerts
- docs/troubleshooting.md (674 lines) - Common issues and solutions
