### PR TITLE
Add Cosign signing for Helm chart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write  # Required for Cosign keyless signing
 
     steps:
       - uses: actions/checkout@v4
@@ -99,6 +100,18 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           CHART_VERSION="${VERSION#v}"
           helm push mcp-operator-${CHART_VERSION}.tgz oci://${{ env.REGISTRY }}/${{ github.repository_owner }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Helm chart with Cosign
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          CHART_VERSION="${VERSION#v}"
+          # Sign the chart using keyless signing (OIDC)
+          cosign sign --yes ${{ env.REGISTRY }}/${{ github.repository_owner }}/mcp-operator:${CHART_VERSION}
+        env:
+          COSIGN_EXPERIMENTAL: 1
 
       - name: Commit chart metadata to main branch
         run: |

--- a/dist/chart/Chart.yaml
+++ b/dist/chart/Chart.yaml
@@ -54,6 +54,10 @@ annotations:
   # Security updates
   artifacthub.io/containsSecurityUpdates: "false"
 
+  # Signing
+  artifacthub.io/signKey: |
+    Signed using Cosign keyless signing with GitHub Actions OIDC
+
   # Changes/Changelog
   artifacthub.io/changes: |
     - kind: added


### PR DESCRIPTION
Implements keyless signing using Cosign with GitHub Actions OIDC:
- Installs Cosign in release workflow
- Signs Helm chart after pushing to GHCR
- Adds id-token: write permission for OIDC
- Updates Chart.yaml with signing information

This will make ArtifactHub show the chart as signed.

Verification:
  cosign verify oci://ghcr.io/vitorbari/mcp-operator:VERSION \
    --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
    --certificate-identity=https://github.com/vitorbari/mcp-operator/.github/workflows/release.yml@refs/tags/vVERSION