### PR TITLE
feat(sidecar): add MCP JSON-RPC protocol parsing

### DIFF
--- a/sidecar/pkg/mcp/parser.go
+++ b/sidecar/pkg/mcp/parser.go
@@ -1,0 +1,279 @@
+package mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Common parsing errors.
+var (
+	ErrEmptyBody     = errors.New("empty body")
+	ErrInvalidJSON   = errors.New("invalid JSON")
+	ErrInvalidFormat = errors.New("invalid JSON-RPC format")
+)
+
+// ParsedRequest contains the parsed information from a JSON-RPC request.
+type ParsedRequest struct {
+	// Method is the JSON-RPC method name.
+	Method string
+
+	// ID is the request ID (nil for notifications).
+	ID *JSONRPCID
+
+	// IsBatch indicates if this was a batch request.
+	IsBatch bool
+
+	// BatchSize is the number of requests in a batch (1 for single requests).
+	BatchSize int
+
+	// IsNotification indicates if this is a notification (no ID).
+	IsNotification bool
+
+	// ToolName is the tool name extracted from tools/call params.
+	ToolName string
+
+	// ResourceURI is the resource URI extracted from resources/read params.
+	ResourceURI string
+
+	// PromptName is the prompt name extracted from prompts/get params.
+	PromptName string
+
+	// Requests contains all parsed requests (for batch support).
+	Requests []JSONRPCRequest
+}
+
+// ParsedResponse contains the parsed information from a JSON-RPC response.
+type ParsedResponse struct {
+	// ID is the response ID.
+	ID *JSONRPCID
+
+	// IsError indicates if this response contains an error.
+	IsError bool
+
+	// ErrorCode is the error code (if IsError is true).
+	ErrorCode int
+
+	// ErrorMessage is the error message (if IsError is true).
+	ErrorMessage string
+
+	// IsBatch indicates if this was a batch response.
+	IsBatch bool
+
+	// BatchSize is the number of responses in a batch (1 for single responses).
+	BatchSize int
+
+	// Responses contains all parsed responses (for batch support).
+	Responses []JSONRPCResponse
+}
+
+// ParseRequest parses a JSON-RPC request body.
+// It supports both single requests and batch requests.
+func ParseRequest(body []byte) (*ParsedRequest, error) {
+	body = bytes.TrimSpace(body)
+
+	if len(body) == 0 {
+		return nil, ErrEmptyBody
+	}
+
+	result := &ParsedRequest{}
+
+	// Check if it's a batch request (starts with '[')
+	if body[0] == '[' {
+		return parseBatchRequest(body)
+	}
+
+	// Parse single request
+	var req JSONRPCRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidJSON, err)
+	}
+
+	// Validate JSON-RPC format
+	if req.JSONRPC != JSONRPCVersion {
+		return nil, fmt.Errorf("%w: invalid or missing jsonrpc version", ErrInvalidFormat)
+	}
+
+	if req.Method == "" {
+		return nil, fmt.Errorf("%w: missing method", ErrInvalidFormat)
+	}
+
+	result.Method = req.Method
+	result.ID = req.ID
+	result.IsBatch = false
+	result.BatchSize = 1
+	result.IsNotification = req.IsNotification()
+	result.Requests = []JSONRPCRequest{req}
+
+	// Extract MCP-specific information
+	extractMCPInfo(result, &req)
+
+	return result, nil
+}
+
+// parseBatchRequest parses a batch JSON-RPC request.
+func parseBatchRequest(body []byte) (*ParsedRequest, error) {
+	var requests []JSONRPCRequest
+	if err := json.Unmarshal(body, &requests); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidJSON, err)
+	}
+
+	if len(requests) == 0 {
+		return nil, fmt.Errorf("%w: empty batch request", ErrInvalidFormat)
+	}
+
+	result := &ParsedRequest{
+		IsBatch:   true,
+		BatchSize: len(requests),
+		Requests:  requests,
+	}
+
+	// Use the first request's method and ID for primary identification
+	firstReq := requests[0]
+	result.Method = firstReq.Method
+	result.ID = firstReq.ID
+	result.IsNotification = firstReq.IsNotification()
+
+	// Extract MCP-specific information from the first request
+	extractMCPInfo(result, &firstReq)
+
+	return result, nil
+}
+
+// extractMCPInfo extracts MCP-specific information from a request.
+func extractMCPInfo(result *ParsedRequest, req *JSONRPCRequest) {
+	if req.Params == nil {
+		return
+	}
+
+	switch req.Method {
+	case MethodToolsCall:
+		var params ToolsCallParams
+		if err := json.Unmarshal(req.Params, &params); err == nil {
+			result.ToolName = params.Name
+		}
+
+	case MethodResourcesRead:
+		var params ResourcesReadParams
+		if err := json.Unmarshal(req.Params, &params); err == nil {
+			result.ResourceURI = params.URI
+		}
+
+	case MethodPromptsGet:
+		var params PromptsGetParams
+		if err := json.Unmarshal(req.Params, &params); err == nil {
+			result.PromptName = params.Name
+		}
+	}
+}
+
+// ParseResponse parses a JSON-RPC response body.
+// It supports both single responses and batch responses.
+func ParseResponse(body []byte) (*ParsedResponse, error) {
+	body = bytes.TrimSpace(body)
+
+	if len(body) == 0 {
+		return nil, ErrEmptyBody
+	}
+
+	// Check if it's a batch response (starts with '[')
+	if body[0] == '[' {
+		return parseBatchResponse(body)
+	}
+
+	// Parse single response
+	var resp JSONRPCResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidJSON, err)
+	}
+
+	result := &ParsedResponse{
+		ID:        resp.ID,
+		IsError:   resp.IsError(),
+		IsBatch:   false,
+		BatchSize: 1,
+		Responses: []JSONRPCResponse{resp},
+	}
+
+	if resp.Error != nil {
+		result.ErrorCode = resp.Error.Code
+		result.ErrorMessage = resp.Error.Message
+	}
+
+	return result, nil
+}
+
+// parseBatchResponse parses a batch JSON-RPC response.
+func parseBatchResponse(body []byte) (*ParsedResponse, error) {
+	var responses []JSONRPCResponse
+	if err := json.Unmarshal(body, &responses); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidJSON, err)
+	}
+
+	if len(responses) == 0 {
+		return nil, fmt.Errorf("%w: empty batch response", ErrInvalidFormat)
+	}
+
+	result := &ParsedResponse{
+		IsBatch:   true,
+		BatchSize: len(responses),
+		Responses: responses,
+	}
+
+	// Use the first response's ID and error status for primary identification
+	firstResp := responses[0]
+	result.ID = firstResp.ID
+	result.IsError = firstResp.IsError()
+
+	if firstResp.Error != nil {
+		result.ErrorCode = firstResp.Error.Code
+		result.ErrorMessage = firstResp.Error.Message
+	}
+
+	return result, nil
+}
+
+// IsMCPMethod returns true if the method is a known MCP method.
+func IsMCPMethod(method string) bool {
+	switch method {
+	case MethodInitialize,
+		MethodInitialized,
+		MethodPing,
+		MethodToolsList,
+		MethodToolsCall,
+		MethodResourcesList,
+		MethodResourcesRead,
+		MethodResourcesTemplates,
+		MethodResourcesSubscribe,
+		MethodResourcesUnsubscribe,
+		MethodPromptsList,
+		MethodPromptsGet,
+		MethodLoggingSetLevel,
+		MethodCompletionComplete:
+		return true
+	default:
+		return false
+	}
+}
+
+// MethodCategory returns the category of an MCP method.
+func MethodCategory(method string) string {
+	switch method {
+	case MethodInitialize, MethodInitialized, MethodPing:
+		return "core"
+	case MethodToolsList, MethodToolsCall:
+		return "tools"
+	case MethodResourcesList, MethodResourcesRead, MethodResourcesTemplates,
+		MethodResourcesSubscribe, MethodResourcesUnsubscribe:
+		return "resources"
+	case MethodPromptsList, MethodPromptsGet:
+		return "prompts"
+	case MethodLoggingSetLevel:
+		return "logging"
+	case MethodCompletionComplete:
+		return "completion"
+	default:
+		return "unknown"
+	}
+}

--- a/sidecar/pkg/mcp/parser_test.go
+++ b/sidecar/pkg/mcp/parser_test.go
@@ -1,0 +1,688 @@
+package mcp
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestParseRequest_SingleRequest(t *testing.T) {
+	tests := []struct {
+		name           string
+		body           string
+		wantMethod     string
+		wantIsBatch    bool
+		wantBatchSize  int
+		wantNotify     bool
+		wantErr        bool
+	}{
+		{
+			name: "initialize request",
+			body: `{
+				"jsonrpc": "2.0",
+				"method": "initialize",
+				"params": {"protocolVersion": "2024-11-05"},
+				"id": 1
+			}`,
+			wantMethod:    MethodInitialize,
+			wantIsBatch:   false,
+			wantBatchSize: 1,
+			wantNotify:    false,
+			wantErr:       false,
+		},
+		{
+			name: "tools/list request",
+			body: `{
+				"jsonrpc": "2.0",
+				"method": "tools/list",
+				"id": 2
+			}`,
+			wantMethod:    MethodToolsList,
+			wantIsBatch:   false,
+			wantBatchSize: 1,
+			wantNotify:    false,
+			wantErr:       false,
+		},
+		{
+			name: "notification (no id)",
+			body: `{
+				"jsonrpc": "2.0",
+				"method": "notifications/initialized"
+			}`,
+			wantMethod:    MethodInitialized,
+			wantIsBatch:   false,
+			wantBatchSize: 1,
+			wantNotify:    true,
+			wantErr:       false,
+		},
+		{
+			name: "string id",
+			body: `{
+				"jsonrpc": "2.0",
+				"method": "ping",
+				"id": "request-123"
+			}`,
+			wantMethod:    MethodPing,
+			wantIsBatch:   false,
+			wantBatchSize: 1,
+			wantNotify:    false,
+			wantErr:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParseRequest([]byte(tt.body))
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseRequest() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if err != nil {
+				return
+			}
+
+			if result.Method != tt.wantMethod {
+				t.Errorf("Method = %v, want %v", result.Method, tt.wantMethod)
+			}
+
+			if result.IsBatch != tt.wantIsBatch {
+				t.Errorf("IsBatch = %v, want %v", result.IsBatch, tt.wantIsBatch)
+			}
+
+			if result.BatchSize != tt.wantBatchSize {
+				t.Errorf("BatchSize = %v, want %v", result.BatchSize, tt.wantBatchSize)
+			}
+
+			if result.IsNotification != tt.wantNotify {
+				t.Errorf("IsNotification = %v, want %v", result.IsNotification, tt.wantNotify)
+			}
+		})
+	}
+}
+
+func TestParseRequest_ToolsCall(t *testing.T) {
+	body := `{
+		"jsonrpc": "2.0",
+		"method": "tools/call",
+		"params": {
+			"name": "get_weather",
+			"arguments": {
+				"location": "San Francisco"
+			}
+		},
+		"id": 1
+	}`
+
+	result, err := ParseRequest([]byte(body))
+	if err != nil {
+		t.Fatalf("ParseRequest() error = %v", err)
+	}
+
+	if result.Method != MethodToolsCall {
+		t.Errorf("Method = %v, want %v", result.Method, MethodToolsCall)
+	}
+
+	if result.ToolName != "get_weather" {
+		t.Errorf("ToolName = %v, want %v", result.ToolName, "get_weather")
+	}
+}
+
+func TestParseRequest_ResourcesRead(t *testing.T) {
+	body := `{
+		"jsonrpc": "2.0",
+		"method": "resources/read",
+		"params": {
+			"uri": "file:///path/to/document.txt"
+		},
+		"id": 1
+	}`
+
+	result, err := ParseRequest([]byte(body))
+	if err != nil {
+		t.Fatalf("ParseRequest() error = %v", err)
+	}
+
+	if result.Method != MethodResourcesRead {
+		t.Errorf("Method = %v, want %v", result.Method, MethodResourcesRead)
+	}
+
+	if result.ResourceURI != "file:///path/to/document.txt" {
+		t.Errorf("ResourceURI = %v, want %v", result.ResourceURI, "file:///path/to/document.txt")
+	}
+}
+
+func TestParseRequest_PromptsGet(t *testing.T) {
+	body := `{
+		"jsonrpc": "2.0",
+		"method": "prompts/get",
+		"params": {
+			"name": "code_review",
+			"arguments": {
+				"language": "go"
+			}
+		},
+		"id": 1
+	}`
+
+	result, err := ParseRequest([]byte(body))
+	if err != nil {
+		t.Fatalf("ParseRequest() error = %v", err)
+	}
+
+	if result.Method != MethodPromptsGet {
+		t.Errorf("Method = %v, want %v", result.Method, MethodPromptsGet)
+	}
+
+	if result.PromptName != "code_review" {
+		t.Errorf("PromptName = %v, want %v", result.PromptName, "code_review")
+	}
+}
+
+func TestParseRequest_BatchRequest(t *testing.T) {
+	body := `[
+		{"jsonrpc": "2.0", "method": "tools/list", "id": 1},
+		{"jsonrpc": "2.0", "method": "resources/list", "id": 2},
+		{"jsonrpc": "2.0", "method": "prompts/list", "id": 3}
+	]`
+
+	result, err := ParseRequest([]byte(body))
+	if err != nil {
+		t.Fatalf("ParseRequest() error = %v", err)
+	}
+
+	if !result.IsBatch {
+		t.Error("IsBatch should be true")
+	}
+
+	if result.BatchSize != 3 {
+		t.Errorf("BatchSize = %v, want %v", result.BatchSize, 3)
+	}
+
+	if len(result.Requests) != 3 {
+		t.Errorf("len(Requests) = %v, want %v", len(result.Requests), 3)
+	}
+
+	// Check first request method
+	if result.Method != MethodToolsList {
+		t.Errorf("Method = %v, want %v", result.Method, MethodToolsList)
+	}
+}
+
+func TestParseRequest_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr error
+	}{
+		{
+			name:    "empty body",
+			body:    "",
+			wantErr: ErrEmptyBody,
+		},
+		{
+			name:    "whitespace only",
+			body:    "   \n\t  ",
+			wantErr: ErrEmptyBody,
+		},
+		{
+			name:    "invalid JSON",
+			body:    `{"jsonrpc": "2.0", "method":`,
+			wantErr: ErrInvalidJSON,
+		},
+		{
+			name:    "missing jsonrpc version",
+			body:    `{"method": "initialize", "id": 1}`,
+			wantErr: ErrInvalidFormat,
+		},
+		{
+			name:    "wrong jsonrpc version",
+			body:    `{"jsonrpc": "1.0", "method": "initialize", "id": 1}`,
+			wantErr: ErrInvalidFormat,
+		},
+		{
+			name:    "missing method",
+			body:    `{"jsonrpc": "2.0", "id": 1}`,
+			wantErr: ErrInvalidFormat,
+		},
+		{
+			name:    "empty batch",
+			body:    `[]`,
+			wantErr: ErrInvalidFormat,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseRequest([]byte(tt.body))
+
+			if err == nil {
+				t.Error("ParseRequest() expected error, got nil")
+				return
+			}
+
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("ParseRequest() error = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseResponse_Success(t *testing.T) {
+	body := `{
+		"jsonrpc": "2.0",
+		"result": {"tools": []},
+		"id": 1
+	}`
+
+	result, err := ParseResponse([]byte(body))
+	if err != nil {
+		t.Fatalf("ParseResponse() error = %v", err)
+	}
+
+	if result.IsError {
+		t.Error("IsError should be false")
+	}
+
+	if result.IsBatch {
+		t.Error("IsBatch should be false")
+	}
+
+	if result.BatchSize != 1 {
+		t.Errorf("BatchSize = %v, want %v", result.BatchSize, 1)
+	}
+}
+
+func TestParseResponse_Error(t *testing.T) {
+	body := `{
+		"jsonrpc": "2.0",
+		"error": {
+			"code": -32601,
+			"message": "Method not found"
+		},
+		"id": 1
+	}`
+
+	result, err := ParseResponse([]byte(body))
+	if err != nil {
+		t.Fatalf("ParseResponse() error = %v", err)
+	}
+
+	if !result.IsError {
+		t.Error("IsError should be true")
+	}
+
+	if result.ErrorCode != MethodNotFound {
+		t.Errorf("ErrorCode = %v, want %v", result.ErrorCode, MethodNotFound)
+	}
+
+	if result.ErrorMessage != "Method not found" {
+		t.Errorf("ErrorMessage = %v, want %v", result.ErrorMessage, "Method not found")
+	}
+}
+
+func TestParseResponse_BatchResponse(t *testing.T) {
+	body := `[
+		{"jsonrpc": "2.0", "result": {"tools": []}, "id": 1},
+		{"jsonrpc": "2.0", "result": {"resources": []}, "id": 2}
+	]`
+
+	result, err := ParseResponse([]byte(body))
+	if err != nil {
+		t.Fatalf("ParseResponse() error = %v", err)
+	}
+
+	if !result.IsBatch {
+		t.Error("IsBatch should be true")
+	}
+
+	if result.BatchSize != 2 {
+		t.Errorf("BatchSize = %v, want %v", result.BatchSize, 2)
+	}
+
+	if len(result.Responses) != 2 {
+		t.Errorf("len(Responses) = %v, want %v", len(result.Responses), 2)
+	}
+}
+
+func TestParseResponse_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr error
+	}{
+		{
+			name:    "empty body",
+			body:    "",
+			wantErr: ErrEmptyBody,
+		},
+		{
+			name:    "invalid JSON",
+			body:    `{"jsonrpc": "2.0", "result":`,
+			wantErr: ErrInvalidJSON,
+		},
+		{
+			name:    "empty batch",
+			body:    `[]`,
+			wantErr: ErrInvalidFormat,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseResponse([]byte(tt.body))
+
+			if err == nil {
+				t.Error("ParseResponse() expected error, got nil")
+				return
+			}
+
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("ParseResponse() error = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestIsMCPMethod(t *testing.T) {
+	tests := []struct {
+		method string
+		want   bool
+	}{
+		{MethodInitialize, true},
+		{MethodToolsList, true},
+		{MethodToolsCall, true},
+		{MethodResourcesList, true},
+		{MethodResourcesRead, true},
+		{MethodPromptsList, true},
+		{MethodPromptsGet, true},
+		{MethodPing, true},
+		{"custom/method", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			if got := IsMCPMethod(tt.method); got != tt.want {
+				t.Errorf("IsMCPMethod(%q) = %v, want %v", tt.method, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMethodCategory(t *testing.T) {
+	tests := []struct {
+		method string
+		want   string
+	}{
+		{MethodInitialize, "core"},
+		{MethodPing, "core"},
+		{MethodToolsList, "tools"},
+		{MethodToolsCall, "tools"},
+		{MethodResourcesList, "resources"},
+		{MethodResourcesRead, "resources"},
+		{MethodPromptsList, "prompts"},
+		{MethodPromptsGet, "prompts"},
+		{MethodLoggingSetLevel, "logging"},
+		{MethodCompletionComplete, "completion"},
+		{"custom/method", "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			if got := MethodCategory(tt.method); got != tt.want {
+				t.Errorf("MethodCategory(%q) = %v, want %v", tt.method, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestJSONRPCID_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantString string
+		wantNumber float64
+		wantIsStr  bool
+		wantIsNull bool
+	}{
+		{
+			name:       "string id",
+			input:      `"request-123"`,
+			wantString: "request-123",
+			wantIsStr:  true,
+		},
+		{
+			name:       "number id",
+			input:      `42`,
+			wantNumber: 42,
+			wantIsStr:  false,
+		},
+		{
+			name:       "float number id",
+			input:      `3.14`,
+			wantNumber: 3.14,
+			wantIsStr:  false,
+		},
+		{
+			name:       "null id",
+			input:      `null`,
+			wantIsNull: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var id JSONRPCID
+			err := json.Unmarshal([]byte(tt.input), &id)
+			if err != nil {
+				t.Fatalf("Unmarshal error: %v", err)
+			}
+
+			if id.IsNull != tt.wantIsNull {
+				t.Errorf("IsNull = %v, want %v", id.IsNull, tt.wantIsNull)
+			}
+
+			if tt.wantIsNull {
+				return
+			}
+
+			if id.IsString != tt.wantIsStr {
+				t.Errorf("IsString = %v, want %v", id.IsString, tt.wantIsStr)
+			}
+
+			if tt.wantIsStr && id.String != tt.wantString {
+				t.Errorf("String = %v, want %v", id.String, tt.wantString)
+			}
+
+			if !tt.wantIsStr && id.Number != tt.wantNumber {
+				t.Errorf("Number = %v, want %v", id.Number, tt.wantNumber)
+			}
+		})
+	}
+}
+
+func TestJSONRPCID_Marshal(t *testing.T) {
+	tests := []struct {
+		name string
+		id   JSONRPCID
+		want string
+	}{
+		{
+			name: "string id",
+			id:   JSONRPCID{String: "test-123", IsString: true},
+			want: `"test-123"`,
+		},
+		{
+			name: "number id",
+			id:   JSONRPCID{Number: 42, IsString: false},
+			want: `42`,
+		},
+		{
+			name: "null id",
+			id:   JSONRPCID{IsNull: true},
+			want: `null`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.id)
+			if err != nil {
+				t.Fatalf("Marshal error: %v", err)
+			}
+
+			if string(data) != tt.want {
+				t.Errorf("Marshal() = %v, want %v", string(data), tt.want)
+			}
+		})
+	}
+}
+
+// Test with real MCP spec examples
+func TestParseRequest_MCPSpecExamples(t *testing.T) {
+	t.Run("initialize from spec", func(t *testing.T) {
+		body := `{
+			"jsonrpc": "2.0",
+			"id": 1,
+			"method": "initialize",
+			"params": {
+				"protocolVersion": "2024-11-05",
+				"capabilities": {
+					"roots": {
+						"listChanged": true
+					},
+					"sampling": {}
+				},
+				"clientInfo": {
+					"name": "ExampleClient",
+					"version": "1.0.0"
+				}
+			}
+		}`
+
+		result, err := ParseRequest([]byte(body))
+		if err != nil {
+			t.Fatalf("ParseRequest() error = %v", err)
+		}
+
+		if result.Method != MethodInitialize {
+			t.Errorf("Method = %v, want %v", result.Method, MethodInitialize)
+		}
+
+		if result.IsNotification {
+			t.Error("initialize should not be a notification")
+		}
+	})
+
+	t.Run("tools/call from spec", func(t *testing.T) {
+		body := `{
+			"jsonrpc": "2.0",
+			"id": 2,
+			"method": "tools/call",
+			"params": {
+				"name": "get_weather",
+				"arguments": {
+					"location": "New York"
+				}
+			}
+		}`
+
+		result, err := ParseRequest([]byte(body))
+		if err != nil {
+			t.Fatalf("ParseRequest() error = %v", err)
+		}
+
+		if result.Method != MethodToolsCall {
+			t.Errorf("Method = %v, want %v", result.Method, MethodToolsCall)
+		}
+
+		if result.ToolName != "get_weather" {
+			t.Errorf("ToolName = %v, want %v", result.ToolName, "get_weather")
+		}
+	})
+
+	t.Run("notification from spec", func(t *testing.T) {
+		body := `{
+			"jsonrpc": "2.0",
+			"method": "notifications/initialized"
+		}`
+
+		result, err := ParseRequest([]byte(body))
+		if err != nil {
+			t.Fatalf("ParseRequest() error = %v", err)
+		}
+
+		if result.Method != MethodInitialized {
+			t.Errorf("Method = %v, want %v", result.Method, MethodInitialized)
+		}
+
+		if !result.IsNotification {
+			t.Error("notifications/initialized should be a notification")
+		}
+	})
+}
+
+func TestParseResponse_MCPSpecExamples(t *testing.T) {
+	t.Run("initialize response", func(t *testing.T) {
+		body := `{
+			"jsonrpc": "2.0",
+			"id": 1,
+			"result": {
+				"protocolVersion": "2024-11-05",
+				"capabilities": {
+					"logging": {},
+					"prompts": {
+						"listChanged": true
+					},
+					"resources": {
+						"subscribe": true,
+						"listChanged": true
+					},
+					"tools": {
+						"listChanged": true
+					}
+				},
+				"serverInfo": {
+					"name": "ExampleServer",
+					"version": "1.0.0"
+				}
+			}
+		}`
+
+		result, err := ParseResponse([]byte(body))
+		if err != nil {
+			t.Fatalf("ParseResponse() error = %v", err)
+		}
+
+		if result.IsError {
+			t.Error("IsError should be false for success response")
+		}
+	})
+
+	t.Run("error response", func(t *testing.T) {
+		body := `{
+			"jsonrpc": "2.0",
+			"id": 1,
+			"error": {
+				"code": -32602,
+				"message": "Invalid params",
+				"data": {"details": "Missing required field 'name'"}
+			}
+		}`
+
+		result, err := ParseResponse([]byte(body))
+		if err != nil {
+			t.Fatalf("ParseResponse() error = %v", err)
+		}
+
+		if !result.IsError {
+			t.Error("IsError should be true for error response")
+		}
+
+		if result.ErrorCode != InvalidParams {
+			t.Errorf("ErrorCode = %v, want %v", result.ErrorCode, InvalidParams)
+		}
+	})
+}

--- a/sidecar/pkg/mcp/protocol.go
+++ b/sidecar/pkg/mcp/protocol.go
@@ -1,0 +1,180 @@
+// Package mcp provides MCP (Model Context Protocol) JSON-RPC message parsing.
+package mcp
+
+import "encoding/json"
+
+// JSON-RPC 2.0 version string.
+const JSONRPCVersion = "2.0"
+
+// MCP method constants for common operations.
+const (
+	// Core protocol methods
+	MethodInitialize = "initialize"
+	MethodInitialized = "notifications/initialized"
+	MethodPing       = "ping"
+
+	// Tools methods
+	MethodToolsList = "tools/list"
+	MethodToolsCall = "tools/call"
+
+	// Resources methods
+	MethodResourcesList     = "resources/list"
+	MethodResourcesRead     = "resources/read"
+	MethodResourcesTemplates = "resources/templates/list"
+	MethodResourcesSubscribe = "resources/subscribe"
+	MethodResourcesUnsubscribe = "resources/unsubscribe"
+
+	// Prompts methods
+	MethodPromptsList = "prompts/list"
+	MethodPromptsGet  = "prompts/get"
+
+	// Logging methods
+	MethodLoggingSetLevel = "logging/setLevel"
+
+	// Completion methods
+	MethodCompletionComplete = "completion/complete"
+)
+
+// JSONRPCID represents a JSON-RPC request/response ID.
+// It can be a string, number, or null.
+type JSONRPCID struct {
+	String  string
+	Number  float64
+	IsString bool
+	IsNull  bool
+}
+
+// UnmarshalJSON implements json.Unmarshaler for JSONRPCID.
+func (id *JSONRPCID) UnmarshalJSON(data []byte) error {
+	// Check for null
+	if string(data) == "null" {
+		id.IsNull = true
+		return nil
+	}
+
+	// Try string first
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		id.String = s
+		id.IsString = true
+		return nil
+	}
+
+	// Try number
+	var n float64
+	if err := json.Unmarshal(data, &n); err == nil {
+		id.Number = n
+		id.IsString = false
+		return nil
+	}
+
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler for JSONRPCID.
+func (id JSONRPCID) MarshalJSON() ([]byte, error) {
+	if id.IsNull {
+		return []byte("null"), nil
+	}
+	if id.IsString {
+		return json.Marshal(id.String)
+	}
+	return json.Marshal(id.Number)
+}
+
+// JSONRPCRequest represents a JSON-RPC 2.0 request.
+type JSONRPCRequest struct {
+	// JSONRPC specifies the JSON-RPC protocol version (must be "2.0").
+	JSONRPC string `json:"jsonrpc"`
+
+	// Method is the name of the method to be invoked.
+	Method string `json:"method"`
+
+	// Params holds the parameter values to be used during invocation.
+	// Can be an object or array.
+	Params json.RawMessage `json:"params,omitempty"`
+
+	// ID is the request identifier. If omitted, this is a notification.
+	ID *JSONRPCID `json:"id,omitempty"`
+}
+
+// IsNotification returns true if this request is a notification (no ID).
+func (r *JSONRPCRequest) IsNotification() bool {
+	return r.ID == nil
+}
+
+// JSONRPCError represents a JSON-RPC 2.0 error object.
+type JSONRPCError struct {
+	// Code is a number indicating the error type.
+	Code int `json:"code"`
+
+	// Message is a short description of the error.
+	Message string `json:"message"`
+
+	// Data contains additional information about the error.
+	Data json.RawMessage `json:"data,omitempty"`
+}
+
+// Standard JSON-RPC 2.0 error codes.
+const (
+	// ParseError indicates invalid JSON was received.
+	ParseError = -32700
+
+	// InvalidRequest indicates the JSON sent is not a valid Request object.
+	InvalidRequest = -32600
+
+	// MethodNotFound indicates the method does not exist or is not available.
+	MethodNotFound = -32601
+
+	// InvalidParams indicates invalid method parameter(s).
+	InvalidParams = -32602
+
+	// InternalError indicates an internal JSON-RPC error.
+	InternalError = -32603
+)
+
+// JSONRPCResponse represents a JSON-RPC 2.0 response.
+type JSONRPCResponse struct {
+	// JSONRPC specifies the JSON-RPC protocol version (must be "2.0").
+	JSONRPC string `json:"jsonrpc"`
+
+	// Result contains the result of the method invocation.
+	// This member is required on success and must not exist on error.
+	Result json.RawMessage `json:"result,omitempty"`
+
+	// Error contains the error object if there was an error.
+	// This member is required on error and must not exist on success.
+	Error *JSONRPCError `json:"error,omitempty"`
+
+	// ID is the request identifier that this response corresponds to.
+	ID *JSONRPCID `json:"id"`
+}
+
+// IsError returns true if this response contains an error.
+func (r *JSONRPCResponse) IsError() bool {
+	return r.Error != nil
+}
+
+// ToolsCallParams represents the parameters for a tools/call request.
+type ToolsCallParams struct {
+	// Name is the name of the tool to call.
+	Name string `json:"name"`
+
+	// Arguments contains the arguments to pass to the tool.
+	Arguments map[string]interface{} `json:"arguments,omitempty"`
+}
+
+// ResourcesReadParams represents the parameters for a resources/read request.
+type ResourcesReadParams struct {
+	// URI is the URI of the resource to read.
+	URI string `json:"uri"`
+}
+
+// PromptsGetParams represents the parameters for a prompts/get request.
+type PromptsGetParams struct {
+	// Name is the name of the prompt to get.
+	Name string `json:"name"`
+
+	// Arguments contains the arguments for the prompt template.
+	Arguments map[string]string `json:"arguments,omitempty"`
+}


### PR DESCRIPTION
Add MCP protocol types and parsing logic for metrics collection:

protocol.go:
- JSON-RPC 2.0 types (Request, Response, Error, ID)
- JSONRPCID supporting string, number, and null values
- MCP method constants (initialize, tools/*, resources/*, prompts/*, etc.)
- Standard JSON-RPC error codes (ParseError, InvalidRequest, etc.)
- Parameter types for tools/call, resources/read, prompts/get

parser.go:
- ParseRequest() for single and batch requests
- ParseResponse() for single and batch responses
- Extracts MCP-specific info: ToolName, ResourceURI, PromptName
- IsMCPMethod() and MethodCategory() helpers
- Proper error handling for empty body, invalid JSON, invalid format

Test coverage:
- Single and batch request/response parsing
- Notification detection (no ID)
- MCP-specific parameter extraction
- Error cases (empty, invalid JSON, missing fields)
- JSONRPCID marshal/unmarshal for all types
- MCP spec examples validation

This is Phase 1, Task 3 of the MCP metrics sidecar implementation.