### PR TITLE
feat(sidecar): add health check endpoints

### DIFF
--- a/sidecar/pkg/config/config.go
+++ b/sidecar/pkg/config/config.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"time"
 )
 
 // Config holds the configuration for the MCP proxy sidecar.
@@ -21,15 +22,19 @@ type Config struct {
 
 	// LogLevel controls the logging verbosity (debug, info, warn, error).
 	LogLevel string
+
+	// HealthCheckInterval is the interval between health checks of the target.
+	HealthCheckInterval time.Duration
 }
 
 // DefaultConfig returns a Config with default values.
 func DefaultConfig() *Config {
 	return &Config{
-		ListenAddr:  ":8080",
-		TargetAddr:  "localhost:3001",
-		MetricsAddr: ":9090",
-		LogLevel:    "info",
+		ListenAddr:          ":8080",
+		TargetAddr:          "localhost:3001",
+		MetricsAddr:         ":9090",
+		LogLevel:            "info",
+		HealthCheckInterval: 10 * time.Second,
 	}
 }
 
@@ -41,6 +46,7 @@ func ParseFlags() *Config {
 	flag.StringVar(&cfg.TargetAddr, "target-addr", cfg.TargetAddr, "Address of the MCP server to proxy to")
 	flag.StringVar(&cfg.MetricsAddr, "metrics-addr", cfg.MetricsAddr, "Address to expose Prometheus metrics on")
 	flag.StringVar(&cfg.LogLevel, "log-level", cfg.LogLevel, "Log level (debug, info, warn, error)")
+	flag.DurationVar(&cfg.HealthCheckInterval, "health-check-interval", cfg.HealthCheckInterval, "Interval between health checks of the target")
 
 	flag.Parse()
 

--- a/sidecar/pkg/health/health.go
+++ b/sidecar/pkg/health/health.go
@@ -1,0 +1,209 @@
+// Package health provides health check endpoints for Kubernetes probes.
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// HealthChecker manages health checks against a target server.
+type HealthChecker struct {
+	targetAddr    string
+	healthy       atomic.Bool
+	ready         atomic.Bool
+	lastCheck     time.Time
+	lastError     error
+	lastLatency   time.Duration
+	checkInterval time.Duration
+	startTime     time.Time
+
+	mu     sync.RWMutex
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// HealthResponse is the JSON response for health endpoints.
+type HealthResponse struct {
+	Status        string                 `json:"status"`
+	Checks        map[string]CheckResult `json:"checks,omitempty"`
+	UptimeSeconds float64                `json:"uptime_seconds"`
+}
+
+// CheckResult represents the result of a single health check.
+type CheckResult struct {
+	Status    string  `json:"status"`
+	LatencyMs float64 `json:"latency_ms,omitempty"`
+	LastCheck string  `json:"last_check,omitempty"`
+	Error     string  `json:"error,omitempty"`
+}
+
+// NewHealthChecker creates a new HealthChecker for the given target.
+func NewHealthChecker(targetAddr string, checkInterval time.Duration) *HealthChecker {
+	hc := &HealthChecker{
+		targetAddr:    targetAddr,
+		checkInterval: checkInterval,
+		startTime:     time.Now(),
+	}
+	// Process is always considered healthy (liveness)
+	hc.healthy.Store(true)
+	// Start as not ready until first check
+	hc.ready.Store(false)
+	return hc
+}
+
+// Start begins the background health checking routine.
+func (hc *HealthChecker) Start(ctx context.Context) {
+	ctx, hc.cancel = context.WithCancel(ctx)
+
+	hc.wg.Add(1)
+	go func() {
+		defer hc.wg.Done()
+		hc.runChecks(ctx)
+	}()
+}
+
+// Stop stops the background health checking routine.
+func (hc *HealthChecker) Stop() {
+	if hc.cancel != nil {
+		hc.cancel()
+	}
+	hc.wg.Wait()
+}
+
+// runChecks runs the health check loop.
+func (hc *HealthChecker) runChecks(ctx context.Context) {
+	// Run initial check immediately
+	hc.checkTarget()
+
+	ticker := time.NewTicker(hc.checkInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			hc.checkTarget()
+		}
+	}
+}
+
+// checkTarget attempts to connect to the target and updates the ready state.
+func (hc *HealthChecker) checkTarget() {
+	start := time.Now()
+
+	// Attempt TCP connection to target
+	conn, err := net.DialTimeout("tcp", hc.targetAddr, 5*time.Second)
+
+	latency := time.Since(start)
+
+	hc.mu.Lock()
+	hc.lastCheck = time.Now()
+	hc.lastLatency = latency
+
+	if err != nil {
+		hc.lastError = err
+		hc.ready.Store(false)
+	} else {
+		conn.Close()
+		hc.lastError = nil
+		hc.ready.Store(true)
+	}
+	hc.mu.Unlock()
+}
+
+// IsHealthy returns the liveness status.
+func (hc *HealthChecker) IsHealthy() bool {
+	return hc.healthy.Load()
+}
+
+// IsReady returns the readiness status.
+func (hc *HealthChecker) IsReady() bool {
+	return hc.ready.Load()
+}
+
+// LivenessHandler returns an HTTP handler for the /healthz endpoint.
+func (hc *HealthChecker) LivenessHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		response := HealthResponse{
+			Status:        "healthy",
+			UptimeSeconds: time.Since(hc.startTime).Seconds(),
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(response)
+	}
+}
+
+// ReadinessHandler returns an HTTP handler for the /readyz endpoint.
+func (hc *HealthChecker) ReadinessHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		hc.mu.RLock()
+		lastCheck := hc.lastCheck
+		lastError := hc.lastError
+		lastLatency := hc.lastLatency
+		hc.mu.RUnlock()
+
+		isReady := hc.ready.Load()
+
+		checkResult := CheckResult{
+			LatencyMs: float64(lastLatency.Milliseconds()),
+		}
+		if !lastCheck.IsZero() {
+			checkResult.LastCheck = lastCheck.Format(time.RFC3339)
+		}
+
+		if isReady {
+			checkResult.Status = "up"
+		} else {
+			checkResult.Status = "down"
+			if lastError != nil {
+				checkResult.Error = lastError.Error()
+			}
+		}
+
+		response := HealthResponse{
+			UptimeSeconds: time.Since(hc.startTime).Seconds(),
+			Checks: map[string]CheckResult{
+				"target": checkResult,
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if isReady {
+			response.Status = "healthy"
+			w.WriteHeader(http.StatusOK)
+		} else {
+			response.Status = "unhealthy"
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+
+		json.NewEncoder(w).Encode(response)
+	}
+}
+
+// TargetAddr returns the target address being checked.
+func (hc *HealthChecker) TargetAddr() string {
+	return hc.targetAddr
+}
+
+// LastCheckResult returns the last check timestamp and error.
+func (hc *HealthChecker) LastCheckResult() (time.Time, error) {
+	hc.mu.RLock()
+	defer hc.mu.RUnlock()
+	return hc.lastCheck, hc.lastError
+}
+
+// String returns a string representation of the health checker.
+func (hc *HealthChecker) String() string {
+	return fmt.Sprintf("HealthChecker{target: %s, ready: %v, interval: %v}",
+		hc.targetAddr, hc.ready.Load(), hc.checkInterval)
+}

--- a/sidecar/pkg/health/health_test.go
+++ b/sidecar/pkg/health/health_test.go
@@ -1,0 +1,329 @@
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestNewHealthChecker(t *testing.T) {
+	hc := NewHealthChecker("localhost:3001", 10*time.Second)
+
+	if hc == nil {
+		t.Fatal("NewHealthChecker returned nil")
+	}
+
+	if hc.TargetAddr() != "localhost:3001" {
+		t.Errorf("expected target addr localhost:3001, got %s", hc.TargetAddr())
+	}
+
+	// Liveness should be true (process is running)
+	if !hc.IsHealthy() {
+		t.Error("expected IsHealthy to be true")
+	}
+
+	// Readiness should be false until first check
+	if hc.IsReady() {
+		t.Error("expected IsReady to be false before first check")
+	}
+}
+
+func TestHealthChecker_LivenessAlwaysReturns200(t *testing.T) {
+	hc := NewHealthChecker("localhost:99999", 10*time.Second)
+
+	req := httptest.NewRequest("GET", "/healthz", nil)
+	rr := httptest.NewRecorder()
+
+	handler := hc.LivenessHandler()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rr.Code)
+	}
+
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %s", ct)
+	}
+
+	body, _ := io.ReadAll(rr.Body)
+	var response HealthResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if response.Status != "healthy" {
+		t.Errorf("expected status 'healthy', got %s", response.Status)
+	}
+
+	if response.UptimeSeconds <= 0 {
+		t.Error("expected positive uptime_seconds")
+	}
+}
+
+func TestHealthChecker_ReadinessReturns200WhenTargetUp(t *testing.T) {
+	// Start a test server to act as the target
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test listener: %v", err)
+	}
+	defer listener.Close()
+
+	targetAddr := listener.Addr().String()
+	hc := NewHealthChecker(targetAddr, 100*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	hc.Start(ctx)
+
+	// Wait for first check
+	time.Sleep(200 * time.Millisecond)
+
+	req := httptest.NewRequest("GET", "/readyz", nil)
+	rr := httptest.NewRecorder()
+
+	handler := hc.ReadinessHandler()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		body, _ := io.ReadAll(rr.Body)
+		t.Errorf("expected status 200, got %d: %s", rr.Code, string(body))
+	}
+
+	body, _ := io.ReadAll(rr.Body)
+	var response HealthResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if response.Status != "healthy" {
+		t.Errorf("expected status 'healthy', got %s", response.Status)
+	}
+
+	if response.Checks["target"].Status != "up" {
+		t.Errorf("expected target status 'up', got %s", response.Checks["target"].Status)
+	}
+
+	hc.Stop()
+}
+
+func TestHealthChecker_ReadinessReturns503WhenTargetDown(t *testing.T) {
+	// Use a port that nothing is listening on
+	hc := NewHealthChecker("127.0.0.1:59999", 100*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	hc.Start(ctx)
+
+	// Wait for first check
+	time.Sleep(200 * time.Millisecond)
+
+	req := httptest.NewRequest("GET", "/readyz", nil)
+	rr := httptest.NewRecorder()
+
+	handler := hc.ReadinessHandler()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status 503, got %d", rr.Code)
+	}
+
+	body, _ := io.ReadAll(rr.Body)
+	var response HealthResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if response.Status != "unhealthy" {
+		t.Errorf("expected status 'unhealthy', got %s", response.Status)
+	}
+
+	if response.Checks["target"].Status != "down" {
+		t.Errorf("expected target status 'down', got %s", response.Checks["target"].Status)
+	}
+
+	if response.Checks["target"].Error == "" {
+		t.Error("expected error message when target is down")
+	}
+
+	hc.Stop()
+}
+
+func TestHealthChecker_BackgroundCheckingUpdatesState(t *testing.T) {
+	// Start a test server to act as the target
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test listener: %v", err)
+	}
+
+	targetAddr := listener.Addr().String()
+	hc := NewHealthChecker(targetAddr, 100*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	hc.Start(ctx)
+
+	// Wait for first check
+	time.Sleep(200 * time.Millisecond)
+
+	// Should be ready
+	if !hc.IsReady() {
+		t.Error("expected IsReady to be true when target is up")
+	}
+
+	lastCheck1, _ := hc.LastCheckResult()
+	if lastCheck1.IsZero() {
+		t.Error("expected last check time to be set")
+	}
+
+	// Close the listener (target goes down)
+	listener.Close()
+
+	// Wait for next check
+	time.Sleep(200 * time.Millisecond)
+
+	// Should not be ready now
+	if hc.IsReady() {
+		t.Error("expected IsReady to be false when target is down")
+	}
+
+	_, lastErr := hc.LastCheckResult()
+	if lastErr == nil {
+		t.Error("expected last error to be set when target is down")
+	}
+
+	hc.Stop()
+}
+
+func TestHealthChecker_Stop(t *testing.T) {
+	hc := NewHealthChecker("localhost:3001", 100*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	hc.Start(ctx)
+
+	// Give it time to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Stop should not hang
+	done := make(chan struct{})
+	go func() {
+		hc.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success
+	case <-time.After(2 * time.Second):
+		t.Error("Stop() did not return in time")
+	}
+}
+
+func TestHealthChecker_ResponseFormat(t *testing.T) {
+	// Start a test server
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test listener: %v", err)
+	}
+	defer listener.Close()
+
+	hc := NewHealthChecker(listener.Addr().String(), 100*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	hc.Start(ctx)
+	defer hc.Stop()
+
+	// Wait for check
+	time.Sleep(200 * time.Millisecond)
+
+	t.Run("liveness response format", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/healthz", nil)
+		rr := httptest.NewRecorder()
+		hc.LivenessHandler().ServeHTTP(rr, req)
+
+		var resp HealthResponse
+		json.NewDecoder(rr.Body).Decode(&resp)
+
+		if resp.Status == "" {
+			t.Error("status field missing")
+		}
+		if resp.UptimeSeconds <= 0 {
+			t.Error("uptime_seconds should be positive")
+		}
+	})
+
+	t.Run("readiness response format", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/readyz", nil)
+		rr := httptest.NewRecorder()
+		hc.ReadinessHandler().ServeHTTP(rr, req)
+
+		var resp HealthResponse
+		json.NewDecoder(rr.Body).Decode(&resp)
+
+		if resp.Status == "" {
+			t.Error("status field missing")
+		}
+		if resp.UptimeSeconds <= 0 {
+			t.Error("uptime_seconds should be positive")
+		}
+		if resp.Checks == nil {
+			t.Error("checks map missing")
+		}
+		if _, ok := resp.Checks["target"]; !ok {
+			t.Error("target check missing")
+		}
+		if resp.Checks["target"].LastCheck == "" {
+			t.Error("last_check missing")
+		}
+	})
+}
+
+func TestHealthChecker_String(t *testing.T) {
+	hc := NewHealthChecker("localhost:3001", 10*time.Second)
+	str := hc.String()
+
+	if str == "" {
+		t.Error("String() should return non-empty string")
+	}
+}
+
+func TestHealthChecker_TargetRecovery(t *testing.T) {
+	// This test verifies that when a target comes back up, readiness is restored
+
+	// Start without target
+	hc := NewHealthChecker("127.0.0.1:59998", 100*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	hc.Start(ctx)
+	defer hc.Stop()
+
+	// Wait for check
+	time.Sleep(200 * time.Millisecond)
+
+	// Should not be ready
+	if hc.IsReady() {
+		t.Error("should not be ready when target is down")
+	}
+
+	// Start a listener on that port
+	listener, err := net.Listen("tcp", "127.0.0.1:59998")
+	if err != nil {
+		t.Fatalf("failed to start listener: %v", err)
+	}
+	defer listener.Close()
+
+	// Wait for next check
+	time.Sleep(200 * time.Millisecond)
+
+	// Should be ready now
+	if !hc.IsReady() {
+		t.Error("should be ready when target is up")
+	}
+}


### PR DESCRIPTION
Add Kubernetes-compatible health endpoints for liveness and readiness probes:

- /healthz (liveness): Always returns 200 if process is running
- /readyz (readiness): Returns 200 only when target MCP server is reachable

Features:
- Background health checking with configurable interval (--health-check-interval)
- JSON response format with status, latency, and error details
- Automatic recovery detection when target comes back online

🤖 Generated with [Claude Code](https://claude.com/claude-code)