### PR TITLE
feat(sidecar): add TLS termination support

### DIFF
--- a/sidecar/pkg/config/config.go
+++ b/sidecar/pkg/config/config.go
@@ -25,6 +25,18 @@ type Config struct {
 
 	// HealthCheckInterval is the interval between health checks of the target.
 	HealthCheckInterval time.Duration
+
+	// TLSEnabled enables TLS termination for incoming connections.
+	TLSEnabled bool
+
+	// TLSCertFile is the path to the TLS certificate file.
+	TLSCertFile string
+
+	// TLSKeyFile is the path to the TLS private key file.
+	TLSKeyFile string
+
+	// TLSMinVersion is the minimum TLS version to accept (1.2 or 1.3).
+	TLSMinVersion string
 }
 
 // DefaultConfig returns a Config with default values.
@@ -35,6 +47,10 @@ func DefaultConfig() *Config {
 		MetricsAddr:         ":9090",
 		LogLevel:            "info",
 		HealthCheckInterval: 10 * time.Second,
+		TLSEnabled:          false,
+		TLSCertFile:         "",
+		TLSKeyFile:          "",
+		TLSMinVersion:       "1.2",
 	}
 }
 
@@ -47,6 +63,10 @@ func ParseFlags() *Config {
 	flag.StringVar(&cfg.MetricsAddr, "metrics-addr", cfg.MetricsAddr, "Address to expose Prometheus metrics on")
 	flag.StringVar(&cfg.LogLevel, "log-level", cfg.LogLevel, "Log level (debug, info, warn, error)")
 	flag.DurationVar(&cfg.HealthCheckInterval, "health-check-interval", cfg.HealthCheckInterval, "Interval between health checks of the target")
+	flag.BoolVar(&cfg.TLSEnabled, "tls-enabled", cfg.TLSEnabled, "Enable TLS termination for incoming connections")
+	flag.StringVar(&cfg.TLSCertFile, "tls-cert-file", cfg.TLSCertFile, "Path to TLS certificate file")
+	flag.StringVar(&cfg.TLSKeyFile, "tls-key-file", cfg.TLSKeyFile, "Path to TLS private key file")
+	flag.StringVar(&cfg.TLSMinVersion, "tls-min-version", cfg.TLSMinVersion, "Minimum TLS version (1.2 or 1.3)")
 
 	flag.Parse()
 

--- a/sidecar/pkg/proxy/tls.go
+++ b/sidecar/pkg/proxy/tls.go
@@ -1,0 +1,120 @@
+// Package proxy provides TLS configuration for the MCP metrics sidecar.
+package proxy
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+// CertExpiryWarningThreshold is the duration before expiry to start warning.
+const CertExpiryWarningThreshold = 30 * 24 * time.Hour // 30 days
+
+// LoadTLSConfig loads and configures TLS settings from certificate files.
+// It returns a tls.Config with secure defaults.
+func LoadTLSConfig(certFile, keyFile, minVersion string) (*tls.Config, error) {
+	// Load certificate and key
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load TLS certificate: %w", err)
+	}
+
+	// Determine minimum TLS version
+	var minVer uint16
+	switch strings.TrimPrefix(strings.ToLower(minVersion), "tls") {
+	case "1.3", "13":
+		minVer = tls.VersionTLS13
+	case "1.2", "12", "":
+		minVer = tls.VersionTLS12
+	default:
+		return nil, fmt.Errorf("unsupported TLS version: %s (supported: 1.2, 1.3)", minVersion)
+	}
+
+	// Configure TLS with secure defaults
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   minVer,
+		// Secure cipher suites (TLS 1.2)
+		// TLS 1.3 cipher suites are not configurable - Go uses secure defaults
+		CipherSuites: []uint16{
+			// TLS 1.3 cipher suites (always enabled when TLS 1.3 is supported)
+			tls.TLS_AES_128_GCM_SHA256,
+			tls.TLS_AES_256_GCM_SHA384,
+			tls.TLS_CHACHA20_POLY1305_SHA256,
+			// TLS 1.2 cipher suites (ECDHE only, no RSA key exchange)
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		},
+		// Prefer server cipher suites
+		PreferServerCipherSuites: true,
+	}
+
+	return tlsConfig, nil
+}
+
+// ValidateCertExpiry parses the certificate file and returns the expiry date.
+// Returns an error if the certificate cannot be parsed.
+func ValidateCertExpiry(certFile string) (time.Time, error) {
+	// Read the certificate file
+	certPEM, err := os.ReadFile(certFile)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to read certificate file: %w", err)
+	}
+
+	// Decode the PEM block
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return time.Time{}, fmt.Errorf("failed to decode PEM block from certificate file")
+	}
+
+	// Parse the certificate
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to parse certificate: %w", err)
+	}
+
+	return cert.NotAfter, nil
+}
+
+// IsCertExpiringSoon checks if the certificate is expiring within the warning threshold.
+func IsCertExpiringSoon(expiry time.Time) bool {
+	return time.Until(expiry) < CertExpiryWarningThreshold
+}
+
+// DaysUntilExpiry returns the number of days until the certificate expires.
+func DaysUntilExpiry(expiry time.Time) int {
+	return int(time.Until(expiry).Hours() / 24)
+}
+
+// ValidateTLSFiles checks that the TLS certificate and key files exist and are readable.
+func ValidateTLSFiles(certFile, keyFile string) error {
+	// Check certificate file
+	if certFile == "" {
+		return fmt.Errorf("TLS certificate file path is required when TLS is enabled")
+	}
+	if _, err := os.Stat(certFile); os.IsNotExist(err) {
+		return fmt.Errorf("TLS certificate file not found: %s", certFile)
+	} else if err != nil {
+		return fmt.Errorf("cannot access TLS certificate file: %w", err)
+	}
+
+	// Check key file
+	if keyFile == "" {
+		return fmt.Errorf("TLS key file path is required when TLS is enabled")
+	}
+	if _, err := os.Stat(keyFile); os.IsNotExist(err) {
+		return fmt.Errorf("TLS key file not found: %s", keyFile)
+	} else if err != nil {
+		return fmt.Errorf("cannot access TLS key file: %w", err)
+	}
+
+	return nil
+}

--- a/sidecar/pkg/proxy/tls_test.go
+++ b/sidecar/pkg/proxy/tls_test.go
@@ -1,0 +1,353 @@
+package proxy
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// generateTestCert creates a self-signed certificate for testing.
+// Returns paths to cert and key files, and a cleanup function.
+func generateTestCert(t *testing.T, notAfter time.Time) (certFile, keyFile string, cleanup func()) {
+	t.Helper()
+
+	// Generate a private key
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate private key: %v", err)
+	}
+
+	// Create a certificate template
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "localhost",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{"localhost"},
+	}
+
+	// Create the certificate
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		t.Fatalf("Failed to create certificate: %v", err)
+	}
+
+	// Create temp directory for cert files
+	tmpDir, err := os.MkdirTemp("", "tls-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+
+	certFile = filepath.Join(tmpDir, "cert.pem")
+	keyFile = filepath.Join(tmpDir, "key.pem")
+
+	// Write certificate
+	certOut, err := os.Create(certFile)
+	if err != nil {
+		t.Fatalf("Failed to create cert file: %v", err)
+	}
+	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: certDER}); err != nil {
+		t.Fatalf("Failed to write cert: %v", err)
+	}
+	certOut.Close()
+
+	// Write private key
+	keyOut, err := os.Create(keyFile)
+	if err != nil {
+		t.Fatalf("Failed to create key file: %v", err)
+	}
+	keyBytes := x509.MarshalPKCS1PrivateKey(privateKey)
+	if err := pem.Encode(keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: keyBytes}); err != nil {
+		t.Fatalf("Failed to write key: %v", err)
+	}
+	keyOut.Close()
+
+	cleanup = func() {
+		os.RemoveAll(tmpDir)
+	}
+
+	return certFile, keyFile, cleanup
+}
+
+func TestLoadTLSConfig(t *testing.T) {
+	// Generate valid cert for testing
+	certFile, keyFile, cleanup := generateTestCert(t, time.Now().Add(365*24*time.Hour))
+	defer cleanup()
+
+	tests := []struct {
+		name       string
+		certFile   string
+		keyFile    string
+		minVersion string
+		wantErr    bool
+		wantMinVer uint16
+	}{
+		{
+			name:       "valid cert with TLS 1.2",
+			certFile:   certFile,
+			keyFile:    keyFile,
+			minVersion: "1.2",
+			wantErr:    false,
+			wantMinVer: tls.VersionTLS12,
+		},
+		{
+			name:       "valid cert with TLS 1.3",
+			certFile:   certFile,
+			keyFile:    keyFile,
+			minVersion: "1.3",
+			wantErr:    false,
+			wantMinVer: tls.VersionTLS13,
+		},
+		{
+			name:       "valid cert with empty version defaults to 1.2",
+			certFile:   certFile,
+			keyFile:    keyFile,
+			minVersion: "",
+			wantErr:    false,
+			wantMinVer: tls.VersionTLS12,
+		},
+		{
+			name:       "invalid TLS version",
+			certFile:   certFile,
+			keyFile:    keyFile,
+			minVersion: "1.1",
+			wantErr:    true,
+		},
+		{
+			name:       "non-existent cert file",
+			certFile:   "/nonexistent/cert.pem",
+			keyFile:    keyFile,
+			minVersion: "1.2",
+			wantErr:    true,
+		},
+		{
+			name:       "non-existent key file",
+			certFile:   certFile,
+			keyFile:    "/nonexistent/key.pem",
+			minVersion: "1.2",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := LoadTLSConfig(tt.certFile, tt.keyFile, tt.minVersion)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LoadTLSConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && cfg.MinVersion != tt.wantMinVer {
+				t.Errorf("LoadTLSConfig() MinVersion = %v, want %v", cfg.MinVersion, tt.wantMinVer)
+			}
+		})
+	}
+}
+
+func TestValidateCertExpiry(t *testing.T) {
+	// Generate cert expiring in 1 year
+	certFile1Year, _, cleanup1 := generateTestCert(t, time.Now().Add(365*24*time.Hour))
+	defer cleanup1()
+
+	// Generate cert expiring in 10 days
+	certFile10Days, _, cleanup2 := generateTestCert(t, time.Now().Add(10*24*time.Hour))
+	defer cleanup2()
+
+	tests := []struct {
+		name          string
+		certFile      string
+		wantErr       bool
+		expectingSoon bool
+	}{
+		{
+			name:          "cert expiring in 1 year",
+			certFile:      certFile1Year,
+			wantErr:       false,
+			expectingSoon: false,
+		},
+		{
+			name:          "cert expiring in 10 days",
+			certFile:      certFile10Days,
+			wantErr:       false,
+			expectingSoon: true,
+		},
+		{
+			name:     "non-existent cert",
+			certFile: "/nonexistent/cert.pem",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expiry, err := ValidateCertExpiry(tt.certFile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCertExpiry() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				isSoon := IsCertExpiringSoon(expiry)
+				if isSoon != tt.expectingSoon {
+					t.Errorf("IsCertExpiringSoon() = %v, want %v", isSoon, tt.expectingSoon)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateTLSFiles(t *testing.T) {
+	// Generate valid cert
+	certFile, keyFile, cleanup := generateTestCert(t, time.Now().Add(365*24*time.Hour))
+	defer cleanup()
+
+	tests := []struct {
+		name     string
+		certFile string
+		keyFile  string
+		wantErr  bool
+	}{
+		{
+			name:     "valid cert and key",
+			certFile: certFile,
+			keyFile:  keyFile,
+			wantErr:  false,
+		},
+		{
+			name:     "empty cert path",
+			certFile: "",
+			keyFile:  keyFile,
+			wantErr:  true,
+		},
+		{
+			name:     "empty key path",
+			certFile: certFile,
+			keyFile:  "",
+			wantErr:  true,
+		},
+		{
+			name:     "non-existent cert",
+			certFile: "/nonexistent/cert.pem",
+			keyFile:  keyFile,
+			wantErr:  true,
+		},
+		{
+			name:     "non-existent key",
+			certFile: certFile,
+			keyFile:  "/nonexistent/key.pem",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateTLSFiles(tt.certFile, tt.keyFile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateTLSFiles() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDaysUntilExpiry(t *testing.T) {
+	tests := []struct {
+		name     string
+		expiry   time.Time
+		wantDays int
+	}{
+		{
+			name:     "30 days from now",
+			expiry:   time.Now().Add(30 * 24 * time.Hour),
+			wantDays: 30,
+		},
+		{
+			name:     "1 day from now",
+			expiry:   time.Now().Add(24 * time.Hour),
+			wantDays: 1,
+		},
+		{
+			name:     "already expired",
+			expiry:   time.Now().Add(-24 * time.Hour),
+			wantDays: -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DaysUntilExpiry(tt.expiry)
+			// Allow +/- 1 day tolerance due to time calculations
+			if got < tt.wantDays-1 || got > tt.wantDays+1 {
+				t.Errorf("DaysUntilExpiry() = %v, want %v (±1)", got, tt.wantDays)
+			}
+		})
+	}
+}
+
+func TestLoadTLSConfig_CipherSuites(t *testing.T) {
+	certFile, keyFile, cleanup := generateTestCert(t, time.Now().Add(365*24*time.Hour))
+	defer cleanup()
+
+	cfg, err := LoadTLSConfig(certFile, keyFile, "1.2")
+	if err != nil {
+		t.Fatalf("LoadTLSConfig() error = %v", err)
+	}
+
+	// Verify secure cipher suites are configured
+	if len(cfg.CipherSuites) == 0 {
+		t.Error("Expected cipher suites to be configured")
+	}
+
+	// Verify PreferServerCipherSuites is set
+	if !cfg.PreferServerCipherSuites {
+		t.Error("Expected PreferServerCipherSuites to be true")
+	}
+}
+
+func TestIsCertExpiringSoon(t *testing.T) {
+	tests := []struct {
+		name     string
+		expiry   time.Time
+		expected bool
+	}{
+		{
+			name:     "expires in 60 days",
+			expiry:   time.Now().Add(60 * 24 * time.Hour),
+			expected: false,
+		},
+		{
+			name:     "expires in 29 days",
+			expiry:   time.Now().Add(29 * 24 * time.Hour),
+			expected: true,
+		},
+		{
+			name:     "expires in 1 day",
+			expiry:   time.Now().Add(24 * time.Hour),
+			expected: true,
+		},
+		{
+			name:     "already expired",
+			expiry:   time.Now().Add(-24 * time.Hour),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsCertExpiringSoon(tt.expiry)
+			if got != tt.expected {
+				t.Errorf("IsCertExpiringSoon() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add optional TLS termination for the sidecar proxy
- Accept HTTPS connections, forward as HTTP to localhost target
- Configure secure TLS defaults (TLS 1.2 minimum, modern cipher suites)
- Validate and warn about certificate expiry (30-day threshold)

## Changes

### Configuration (`pkg/config/config.go`)
- `TLSEnabled` (bool) - Enable/disable TLS termination
- `TLSCertFile` (string) - Path to certificate file
- `TLSKeyFile` (string) - Path to private key file
- `TLSMinVersion` (string) - Minimum TLS version (default: 1.2)

### TLS Implementation (`pkg/proxy/tls.go`)
- `LoadTLSConfig()` - Load TLS configuration with secure defaults
- `ValidateCertExpiry()` - Parse cert and return expiry date
- `IsCertExpiringSoon()` - Check if expiring within 30 days
- `ValidateTLSFiles()` - Pre-flight validation of cert/key files

### Proxy (`pkg/proxy/proxy.go`)
- Add `StartWithTLS()` method for HTTPS server

### Main (`cmd/mcp-proxy/main.go`)
- Add `--tls-enabled`, `--tls-cert-file`, `--tls-key-file`, `--tls-min-version` flags
- Validate TLS configuration on startup
- Log certificate expiry with warning if expiring soon

## Test Plan

- [x] Unit tests for TLS config loading and validation
- [x] Unit tests for certificate expiry detection
- [x] Manual test with self-signed certificate
- [x] Verify HTTPS connections work with `curl -k`
- [x] Verify metrics endpoint stays HTTP-only
- [x] Verify error messages for missing/invalid certs

## Usage

```bash
# Generate self-signed certificate
openssl req -x509 -newkey rsa:4096 \
  -keyout /tmp/certs/key.pem \
  -out /tmp/certs/cert.pem \
  -days 365 -nodes \
  -subj "/CN=localhost"

# Start proxy with TLS
go run ./cmd/mcp-proxy \
  --target-addr=localhost:3002 \
  --listen-addr=:8443 \
  --metrics-addr=:9090 \
  --tls-enabled \
  --tls-cert-file=/tmp/certs/cert.pem \
  --tls-key-file=/tmp/certs/key.pem

# Test HTTPS
curl -k https://localhost:8443/mcp ...

# Metrics still on HTTP
curl http://localhost:9090/metrics
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)