### PR TITLE
feat(sidecar): add Kubernetes test deployment manifests

### DIFF
--- a/sidecar/deploy/README.md
+++ b/sidecar/deploy/README.md
@@ -1,0 +1,137 @@
+# MCP Proxy Sidecar Test Deployment
+
+This directory contains Kubernetes manifests for manually testing the MCP metrics sidecar proxy before operator integration.
+
+## Prerequisites
+
+- Kubernetes cluster (Kind, Minikube, or other)
+- kubectl configured
+- (Optional) Prometheus Operator for ServiceMonitor support
+
+## Building and Pushing the Image
+
+Before deploying, build and push the sidecar image:
+
+```bash
+cd sidecar
+
+# Build the image
+docker build -t ghcr.io/vitorbari/mcp-proxy:dev .
+
+# Push to registry (requires authentication)
+docker push ghcr.io/vitorbari/mcp-proxy:dev
+
+# For Kind clusters, load the image directly:
+kind load docker-image ghcr.io/vitorbari/mcp-proxy:dev --name <cluster-name>
+```
+
+Update `test-pod.yaml` to use `:dev` tag if not using `:latest`.
+
+## Deploying
+
+```bash
+# Deploy all manifests
+kubectl apply -f sidecar/deploy/
+
+# Wait for pod to be ready
+kubectl wait --for=condition=ready pod -l app=mcp-test --timeout=60s
+
+# Verify both containers are running
+kubectl get pod -l app=mcp-test
+```
+
+## Verifying the Deployment
+
+### Check Pod Status
+
+```bash
+# List containers in the pod
+kubectl get pod -l app=mcp-test -o jsonpath='{.items[0].spec.containers[*].name}'
+# Expected: mcp-server mcp-proxy
+
+# Check container readiness
+kubectl get pod -l app=mcp-test -o jsonpath='{.items[0].status.containerStatuses[*].ready}'
+# Expected: true true
+
+# View logs
+kubectl logs -l app=mcp-test -c mcp-proxy
+kubectl logs -l app=mcp-test -c mcp-server
+```
+
+### Port Forwarding
+
+```bash
+# Forward both MCP and metrics ports
+kubectl port-forward svc/mcp-test 8080:8080 9090:9090
+```
+
+### Testing MCP Requests
+
+```bash
+# Initialize connection (note: path is /mcp for Streamable HTTP)
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}},"id":1}'
+
+# List available tools
+curl -X POST http://localhost:8080/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","method":"tools/list","params":{},"id":2}'
+```
+
+### Using MCP Inspector
+
+You can also test using MCP Inspector:
+
+1. Open MCP Inspector at http://localhost:6274/
+2. Connect to: `http://localhost:8080/mcp`
+3. Use the Inspector UI to explore tools, resources, and prompts
+
+### Health Checks
+
+```bash
+# Liveness probe
+curl http://localhost:9090/healthz
+
+# Readiness probe
+curl http://localhost:9090/readyz
+```
+
+### Metrics
+
+```bash
+# View all metrics
+curl http://localhost:9090/metrics
+
+# Filter MCP-specific metrics
+curl -s http://localhost:9090/metrics | grep mcp_
+```
+
+## Prometheus Integration
+
+If you have Prometheus Operator installed, the ServiceMonitor will automatically configure Prometheus to scrape metrics from the sidecar.
+
+```bash
+# Check if ServiceMonitor is created
+kubectl get servicemonitor mcp-test
+
+# Verify in Prometheus UI (port-forward if needed)
+kubectl port-forward svc/prometheus-operated 9090:9090 -n monitoring
+# Then open http://localhost:9090 and search for mcp_* metrics
+```
+
+## Cleanup
+
+```bash
+kubectl delete -f sidecar/deploy/
+```
+
+## Manifest Overview
+
+| File | Description |
+|------|-------------|
+| `test-pod.yaml` | Pod with MCP server and proxy sidecar containers |
+| `service.yaml` | Service exposing MCP (8080) and metrics (9090) ports |
+| `servicemonitor.yaml` | Prometheus ServiceMonitor for automatic scraping |

--- a/sidecar/deploy/service.yaml
+++ b/sidecar/deploy/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-test
+  labels:
+    app: mcp-test
+spec:
+  selector:
+    app: mcp-test
+  ports:
+    - name: mcp
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+    - name: metrics
+      port: 9090
+      targetPort: 9090
+      protocol: TCP

--- a/sidecar/deploy/servicemonitor.yaml
+++ b/sidecar/deploy/servicemonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: mcp-test
+  labels:
+    app: mcp-test
+spec:
+  selector:
+    matchLabels:
+      app: mcp-test
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s

--- a/sidecar/deploy/test-pod.yaml
+++ b/sidecar/deploy/test-pod.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mcp-test
+  labels:
+    app: mcp-test
+spec:
+  containers:
+    # MCP Server container
+    - name: mcp-server
+      image: tzolov/mcp-everything-server:v3
+      command: ["node", "dist/index.js", "streamableHttp"]
+      ports:
+        - containerPort: 3001
+          name: mcp-server
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 256Mi
+
+    # MCP Proxy sidecar container
+    - name: mcp-proxy
+      image: ghcr.io/vitorbari/mcp-proxy:latest
+      args:
+        - --target-addr=localhost:3001
+        - --listen-addr=:8080
+        - --metrics-addr=:9090
+        - --log-level=info
+      ports:
+        - containerPort: 8080
+          name: mcp
+        - containerPort: 9090
+          name: metrics
+      livenessProbe:
+        httpGet:
+          path: /healthz
+          port: 9090
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 3
+      readinessProbe:
+        httpGet:
+          path: /readyz
+          port: 9090
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 3
+        failureThreshold: 3
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 200m
+          memory: 128Mi


### PR DESCRIPTION
## Summary

Add Kubernetes manifests for manually testing the MCP proxy sidecar before operator integration.

## Files

| File | Description |
|------|-------------|
| `test-pod.yaml` | Pod with MCP server and proxy sidecar containers |
| `service.yaml` | Service exposing MCP (8080) and metrics (9090) ports |
| `servicemonitor.yaml` | Prometheus ServiceMonitor for automatic scraping |
| `README.md` | Deployment and testing instructions |

## Test Plan

- [x] Deploy to Kind cluster with Prometheus Operator
- [x] Verify both containers are healthy (2/2 Running)
- [x] Test MCP requests through proxy (`/mcp` endpoint)
- [x] Verify metrics exposed and scraped
- [x] Verify health endpoints work (`/healthz`, `/readyz`)

## Usage

```bash
# Deploy
kubectl apply -f sidecar/deploy/

# Wait for ready
kubectl wait --for=condition=ready pod -l app=mcp-test --timeout=60s

# Port forward
kubectl port-forward svc/mcp-test 8080:8080 9090:9090

# Test MCP
curl -X POST http://localhost:8080/mcp \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -d '{"jsonrpc":"2.0","method":"initialize",...}'

# Or use MCP Inspector at http://localhost:6274/
# Connect to http://localhost:8080/mcp

# Cleanup
kubectl delete -f sidecar/deploy/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)