### PR TITLE
feat(observability): add sidecar metrics to Grafana dashboard

### DIFF
--- a/config/grafana/dashboard.json
+++ b/config/grafana/dashboard.json
@@ -1720,6 +1720,1744 @@
             ],
             "title": "Servers with Each Capability",
             "type": "bargauge"
+        },
+        {
+            "collapsed": true,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 45
+            },
+            "id": 400,
+            "panels": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Current request rate across all MCP servers with sidecar metrics enabled",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "mappings": [],
+                            "noValue": "No sidecar data",
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "blue",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "reqps"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 4,
+                        "w": 4,
+                        "x": 0,
+                        "y": 46
+                    },
+                    "id": 401,
+                    "options": {
+                        "colorMode": "value",
+                        "graphMode": "area",
+                        "justifyMode": "auto",
+                        "orientation": "auto",
+                        "percentChangeColorMode": "standard",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "showPercentChange": false,
+                        "textMode": "value",
+                        "wideLayout": true
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "sum(rate(mcp_requests_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m]))",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Request Rate",
+                    "type": "stat"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Percentage of requests resulting in errors",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "decimals": 2,
+                            "mappings": [],
+                            "max": 100,
+                            "min": 0,
+                            "noValue": "No sidecar data",
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "yellow",
+                                        "value": 1
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 5
+                                    }
+                                ]
+                            },
+                            "unit": "percent"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 4,
+                        "w": 4,
+                        "x": 4,
+                        "y": 46
+                    },
+                    "id": 402,
+                    "options": {
+                        "colorMode": "background",
+                        "graphMode": "area",
+                        "justifyMode": "auto",
+                        "orientation": "auto",
+                        "percentChangeColorMode": "standard",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "showPercentChange": false,
+                        "textMode": "value",
+                        "wideLayout": true
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "100 * (sum(rate(mcp_request_errors_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) / sum(rate(mcp_requests_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])))",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Error Rate",
+                    "type": "stat"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Current number of active HTTP connections",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "mappings": [],
+                            "noValue": "No sidecar data",
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "blue",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "short"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 4,
+                        "w": 4,
+                        "x": 8,
+                        "y": 46
+                    },
+                    "id": 403,
+                    "options": {
+                        "colorMode": "value",
+                        "graphMode": "area",
+                        "justifyMode": "auto",
+                        "orientation": "auto",
+                        "percentChangeColorMode": "standard",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "showPercentChange": false,
+                        "textMode": "value",
+                        "wideLayout": true
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "sum(mcp_active_connections{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"})",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Active Connections",
+                    "type": "stat"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Current number of active SSE streaming connections",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "mappings": [],
+                            "noValue": "No sidecar data",
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "purple",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "short"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 4,
+                        "w": 4,
+                        "x": 12,
+                        "y": 46
+                    },
+                    "id": 404,
+                    "options": {
+                        "colorMode": "value",
+                        "graphMode": "area",
+                        "justifyMode": "auto",
+                        "orientation": "auto",
+                        "percentChangeColorMode": "standard",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "showPercentChange": false,
+                        "textMode": "value",
+                        "wideLayout": true
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "sum(mcp_sse_connections_active{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"})",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "SSE Connections",
+                    "type": "stat"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Median request latency (50th percentile)",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "decimals": 3,
+                            "mappings": [],
+                            "noValue": "No sidecar data",
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "yellow",
+                                        "value": 0.5
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 2
+                                    }
+                                ]
+                            },
+                            "unit": "s"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 4,
+                        "w": 4,
+                        "x": 16,
+                        "y": 46
+                    },
+                    "id": 405,
+                    "options": {
+                        "colorMode": "background",
+                        "graphMode": "area",
+                        "justifyMode": "auto",
+                        "orientation": "auto",
+                        "percentChangeColorMode": "standard",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "showPercentChange": false,
+                        "textMode": "value",
+                        "wideLayout": true
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "histogram_quantile(0.5, sum(rate(mcp_request_duration_seconds_bucket{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (le))",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "p50 Latency",
+                    "type": "stat"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "95th percentile request latency",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "decimals": 3,
+                            "mappings": [],
+                            "noValue": "No sidecar data",
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "yellow",
+                                        "value": 0.5
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 2
+                                    }
+                                ]
+                            },
+                            "unit": "s"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 4,
+                        "w": 4,
+                        "x": 20,
+                        "y": 46
+                    },
+                    "id": 406,
+                    "options": {
+                        "colorMode": "background",
+                        "graphMode": "area",
+                        "justifyMode": "auto",
+                        "orientation": "auto",
+                        "percentChangeColorMode": "standard",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "showPercentChange": false,
+                        "textMode": "value",
+                        "wideLayout": true
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "histogram_quantile(0.95, sum(rate(mcp_request_duration_seconds_bucket{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (le))",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "p95 Latency",
+                    "type": "stat"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Request rate broken down by JSON-RPC method",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "barWidthFactor": 0.6,
+                                "drawStyle": "line",
+                                "fillOpacity": 20,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 2,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "normal"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "reqps"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 12,
+                        "x": 0,
+                        "y": 50
+                    },
+                    "id": 407,
+                    "options": {
+                        "legend": {
+                            "calcs": [
+                                "mean",
+                                "max"
+                            ],
+                            "displayMode": "table",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "hideZeros": false,
+                            "mode": "multi",
+                            "sort": "desc"
+                        }
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "sum(rate(mcp_requests_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (method)",
+                            "legendFormat": "{{method}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Requests by Method",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Request rate by HTTP status code category",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "barWidthFactor": 0.6,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 2,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "reqps"
+                        },
+                        "overrides": [
+                            {
+                                "matcher": {
+                                    "id": "byRegexp",
+                                    "options": "2.."
+                                },
+                                "properties": [
+                                    {
+                                        "id": "color",
+                                        "value": {
+                                            "fixedColor": "green",
+                                            "mode": "fixed"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "matcher": {
+                                    "id": "byRegexp",
+                                    "options": "4.."
+                                },
+                                "properties": [
+                                    {
+                                        "id": "color",
+                                        "value": {
+                                            "fixedColor": "yellow",
+                                            "mode": "fixed"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "matcher": {
+                                    "id": "byRegexp",
+                                    "options": "5.."
+                                },
+                                "properties": [
+                                    {
+                                        "id": "color",
+                                        "value": {
+                                            "fixedColor": "red",
+                                            "mode": "fixed"
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 12,
+                        "x": 12,
+                        "y": 50
+                    },
+                    "id": 408,
+                    "options": {
+                        "legend": {
+                            "calcs": [
+                                "mean",
+                                "max"
+                            ],
+                            "displayMode": "table",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "hideZeros": false,
+                            "mode": "multi",
+                            "sort": "desc"
+                        }
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "sum(rate(mcp_requests_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (status)",
+                            "legendFormat": "{{status}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Requests by Status",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Request latency percentiles (p50, p90, p95, p99) over time",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "barWidthFactor": 0.6,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 2,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "s"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 12,
+                        "x": 0,
+                        "y": 58
+                    },
+                    "id": 409,
+                    "options": {
+                        "legend": {
+                            "calcs": [
+                                "lastNotNull",
+                                "mean",
+                                "max"
+                            ],
+                            "displayMode": "table",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "hideZeros": false,
+                            "mode": "multi",
+                            "sort": "desc"
+                        }
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "histogram_quantile(0.50, sum(rate(mcp_request_duration_seconds_bucket{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (le))",
+                            "legendFormat": "p50",
+                            "refId": "A"
+                        },
+                        {
+                            "expr": "histogram_quantile(0.90, sum(rate(mcp_request_duration_seconds_bucket{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (le))",
+                            "legendFormat": "p90",
+                            "refId": "B"
+                        },
+                        {
+                            "expr": "histogram_quantile(0.95, sum(rate(mcp_request_duration_seconds_bucket{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (le))",
+                            "legendFormat": "p95",
+                            "refId": "C"
+                        },
+                        {
+                            "expr": "histogram_quantile(0.99, sum(rate(mcp_request_duration_seconds_bucket{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (le))",
+                            "legendFormat": "p99",
+                            "refId": "D"
+                        }
+                    ],
+                    "title": "Latency Percentiles",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "95th percentile latency broken down by JSON-RPC method",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "barWidthFactor": 0.6,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 2,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "s"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 12,
+                        "x": 12,
+                        "y": 58
+                    },
+                    "id": 410,
+                    "options": {
+                        "legend": {
+                            "calcs": [
+                                "lastNotNull",
+                                "mean",
+                                "max"
+                            ],
+                            "displayMode": "table",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "hideZeros": false,
+                            "mode": "multi",
+                            "sort": "desc"
+                        }
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "histogram_quantile(0.95, sum(rate(mcp_request_duration_seconds_bucket{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (le, method))",
+                            "legendFormat": "{{method}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "p95 Latency by Method",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Tool call rate broken down by tool name - shows which MCP tools are being used",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "barWidthFactor": 0.6,
+                                "drawStyle": "line",
+                                "fillOpacity": 20,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 2,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "normal"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "reqps"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 12,
+                        "x": 0,
+                        "y": 66
+                    },
+                    "id": 411,
+                    "options": {
+                        "legend": {
+                            "calcs": [
+                                "mean",
+                                "sum"
+                            ],
+                            "displayMode": "table",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "hideZeros": false,
+                            "mode": "multi",
+                            "sort": "desc"
+                        }
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "sum(rate(mcp_tool_calls_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (tool_name)",
+                            "legendFormat": "{{tool_name}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Tool Calls Over Time",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Top 10 most called MCP tools in the last 24 hours",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "short"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 12,
+                        "x": 12,
+                        "y": 66
+                    },
+                    "id": 412,
+                    "options": {
+                        "displayMode": "gradient",
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": false
+                        },
+                        "maxVizHeight": 300,
+                        "minVizHeight": 16,
+                        "minVizWidth": 8,
+                        "namePlacement": "auto",
+                        "orientation": "horizontal",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "showUnfilled": true,
+                        "sizing": "auto",
+                        "valueMode": "color"
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "topk(10, sum(increase(mcp_tool_calls_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[24h])) by (tool_name))",
+                            "legendFormat": "{{tool_name}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Top 10 Tools (24h)",
+                    "type": "bargauge"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Resource read rate broken down by resource URI",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "barWidthFactor": 0.6,
+                                "drawStyle": "line",
+                                "fillOpacity": 20,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 2,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "normal"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "reqps"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 12,
+                        "x": 0,
+                        "y": 74
+                    },
+                    "id": 413,
+                    "options": {
+                        "legend": {
+                            "calcs": [
+                                "mean",
+                                "sum"
+                            ],
+                            "displayMode": "table",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "hideZeros": false,
+                            "mode": "multi",
+                            "sort": "desc"
+                        }
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "sum(rate(mcp_resource_reads_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (resource_uri)",
+                            "legendFormat": "{{resource_uri}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Resource Reads Over Time",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Top 10 most accessed MCP resources in the last 24 hours",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "short"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 12,
+                        "x": 12,
+                        "y": 74
+                    },
+                    "id": 414,
+                    "options": {
+                        "displayMode": "gradient",
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": false
+                        },
+                        "maxVizHeight": 300,
+                        "minVizHeight": 16,
+                        "minVizWidth": 8,
+                        "namePlacement": "auto",
+                        "orientation": "horizontal",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "showUnfilled": true,
+                        "sizing": "auto",
+                        "valueMode": "color"
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "topk(10, sum(increase(mcp_resource_reads_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[24h])) by (resource_uri))",
+                            "legendFormat": "{{resource_uri}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Top 10 Resources (24h)",
+                    "type": "bargauge"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Number of active SSE connections over time",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "barWidthFactor": 0.6,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 2,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "min": 0,
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "short"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 8,
+                        "x": 0,
+                        "y": 82
+                    },
+                    "id": 415,
+                    "options": {
+                        "legend": {
+                            "calcs": [
+                                "lastNotNull",
+                                "mean",
+                                "max"
+                            ],
+                            "displayMode": "table",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "hideZeros": false,
+                            "mode": "multi",
+                            "sort": "desc"
+                        }
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "sum(mcp_sse_connections_active{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}) by (mcpserver)",
+                            "legendFormat": "{{mcpserver}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Active SSE Connections",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "SSE connection duration percentiles showing how long connections stay open",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "barWidthFactor": 0.6,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 2,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "s"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 8,
+                        "x": 8,
+                        "y": 82
+                    },
+                    "id": 416,
+                    "options": {
+                        "legend": {
+                            "calcs": [
+                                "lastNotNull",
+                                "mean"
+                            ],
+                            "displayMode": "table",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "hideZeros": false,
+                            "mode": "multi",
+                            "sort": "desc"
+                        }
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "histogram_quantile(0.50, sum(rate(mcp_sse_connection_duration_seconds_bucket{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (le))",
+                            "legendFormat": "p50",
+                            "refId": "A"
+                        },
+                        {
+                            "expr": "histogram_quantile(0.95, sum(rate(mcp_sse_connection_duration_seconds_bucket{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (le))",
+                            "legendFormat": "p95",
+                            "refId": "B"
+                        }
+                    ],
+                    "title": "SSE Connection Duration",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "SSE event throughput by event type",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "barWidthFactor": 0.6,
+                                "drawStyle": "line",
+                                "fillOpacity": 20,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 2,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "normal"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "reqps"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 8,
+                        "x": 16,
+                        "y": 82
+                    },
+                    "id": 417,
+                    "options": {
+                        "legend": {
+                            "calcs": [
+                                "mean",
+                                "sum"
+                            ],
+                            "displayMode": "table",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "hideZeros": false,
+                            "mode": "multi",
+                            "sort": "desc"
+                        }
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "sum(rate(mcp_sse_events_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (event_type)",
+                            "legendFormat": "{{event_type}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "SSE Events by Type",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Error rate broken down by JSON-RPC method",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "barWidthFactor": 0.6,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 2,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "reqps"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 12,
+                        "x": 0,
+                        "y": 90
+                    },
+                    "id": 418,
+                    "options": {
+                        "legend": {
+                            "calcs": [
+                                "mean",
+                                "sum"
+                            ],
+                            "displayMode": "table",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "hideZeros": false,
+                            "mode": "multi",
+                            "sort": "desc"
+                        }
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "sum(rate(mcp_request_errors_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (method)",
+                            "legendFormat": "{{method}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Errors by Method",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Error rate broken down by JSON-RPC error code",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "barWidthFactor": 0.6,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 2,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "reqps"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 12,
+                        "x": 12,
+                        "y": 90
+                    },
+                    "id": 419,
+                    "options": {
+                        "legend": {
+                            "calcs": [
+                                "mean",
+                                "sum"
+                            ],
+                            "displayMode": "table",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "hideZeros": false,
+                            "mode": "multi",
+                            "sort": "desc"
+                        }
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "sum(rate(mcp_request_errors_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (error_code)",
+                            "legendFormat": "{{error_code}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Errors by Code",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Recent errors in the last hour broken down by method and error code",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "custom": {
+                                "align": "auto",
+                                "cellOptions": {
+                                    "type": "auto"
+                                },
+                                "inspect": false
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "yellow",
+                                        "value": 1
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 10
+                                    }
+                                ]
+                            }
+                        },
+                        "overrides": [
+                            {
+                                "matcher": {
+                                    "id": "byName",
+                                    "options": "Value"
+                                },
+                                "properties": [
+                                    {
+                                        "id": "displayName",
+                                        "value": "Error Count"
+                                    },
+                                    {
+                                        "id": "custom.cellOptions",
+                                        "value": {
+                                            "mode": "gradient",
+                                            "type": "color-background"
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 24,
+                        "x": 0,
+                        "y": 98
+                    },
+                    "id": 420,
+                    "options": {
+                        "cellHeight": "sm",
+                        "footer": {
+                            "countRows": false,
+                            "fields": "",
+                            "reducer": [
+                                "sum"
+                            ],
+                            "show": false
+                        },
+                        "showHeader": true,
+                        "sortBy": [
+                            {
+                                "desc": true,
+                                "displayName": "Error Count"
+                            }
+                        ]
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "sum(increase(mcp_request_errors_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[1h])) by (mcpserver, method, error_code) > 0",
+                            "format": "table",
+                            "instant": true,
+                            "legendFormat": "",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Error Log (Last Hour)",
+                    "transformations": [
+                        {
+                            "id": "organize",
+                            "options": {
+                                "excludeByName": {
+                                    "Time": true
+                                },
+                                "indexByName": {
+                                    "Time": 0,
+                                    "Value": 4,
+                                    "error_code": 3,
+                                    "mcpserver": 1,
+                                    "method": 2
+                                },
+                                "renameByName": {
+                                    "error_code": "Error Code",
+                                    "mcpserver": "MCP Server",
+                                    "method": "Method"
+                                }
+                            }
+                        }
+                    ],
+                    "type": "table"
+                }
+            ],
+            "title": "Sidecar Metrics",
+            "type": "row"
         }
     ],
     "preload": false,
@@ -1729,10 +3467,71 @@
         "mcp",
         "operator",
         "protocol",
-        "validation"
+        "validation",
+        "sidecar",
+        "metrics"
     ],
     "templating": {
-        "list": []
+        "list": [
+            {
+                "allValue": ".*",
+                "current": {
+                    "selected": true,
+                    "text": "All",
+                    "value": "$__all"
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                },
+                "definition": "label_values(mcp_requests_total, namespace)",
+                "hide": 0,
+                "includeAll": true,
+                "label": "Namespace",
+                "multi": false,
+                "name": "namespace",
+                "options": [],
+                "query": {
+                    "qryType": 1,
+                    "query": "label_values(mcp_requests_total, namespace)",
+                    "refId": "PrometheusVariableQueryEditor-VariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "type": "query"
+            },
+            {
+                "allValue": ".*",
+                "current": {
+                    "selected": true,
+                    "text": "All",
+                    "value": "$__all"
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                },
+                "definition": "label_values(mcp_requests_total{namespace=~\"$namespace\"}, mcpserver)",
+                "hide": 0,
+                "includeAll": true,
+                "label": "MCP Server",
+                "multi": true,
+                "name": "mcpserver",
+                "options": [],
+                "query": {
+                    "qryType": 1,
+                    "query": "label_values(mcp_requests_total{namespace=~\"$namespace\"}, mcpserver)",
+                    "refId": "PrometheusVariableQueryEditor-VariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "type": "query"
+            }
+        ]
     },
     "time": {
         "from": "now-24h",

--- a/dist/chart/dashboards/dashboard.json
+++ b/dist/chart/dashboards/dashboard.json
@@ -1720,6 +1720,1744 @@
             ],
             "title": "Servers with Each Capability",
             "type": "bargauge"
+        },
+        {
+            "collapsed": true,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 45
+            },
+            "id": 400,
+            "panels": [
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Current request rate across all MCP servers with sidecar metrics enabled",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "mappings": [],
+                            "noValue": "No sidecar data",
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "blue",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "reqps"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 4,
+                        "w": 4,
+                        "x": 0,
+                        "y": 46
+                    },
+                    "id": 401,
+                    "options": {
+                        "colorMode": "value",
+                        "graphMode": "area",
+                        "justifyMode": "auto",
+                        "orientation": "auto",
+                        "percentChangeColorMode": "standard",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "showPercentChange": false,
+                        "textMode": "value",
+                        "wideLayout": true
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "sum(rate(mcp_requests_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m]))",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Request Rate",
+                    "type": "stat"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Percentage of requests resulting in errors",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "decimals": 2,
+                            "mappings": [],
+                            "max": 100,
+                            "min": 0,
+                            "noValue": "No sidecar data",
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "yellow",
+                                        "value": 1
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 5
+                                    }
+                                ]
+                            },
+                            "unit": "percent"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 4,
+                        "w": 4,
+                        "x": 4,
+                        "y": 46
+                    },
+                    "id": 402,
+                    "options": {
+                        "colorMode": "background",
+                        "graphMode": "area",
+                        "justifyMode": "auto",
+                        "orientation": "auto",
+                        "percentChangeColorMode": "standard",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "showPercentChange": false,
+                        "textMode": "value",
+                        "wideLayout": true
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "100 * (sum(rate(mcp_request_errors_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) / sum(rate(mcp_requests_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])))",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Error Rate",
+                    "type": "stat"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Current number of active HTTP connections",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "mappings": [],
+                            "noValue": "No sidecar data",
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "blue",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "short"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 4,
+                        "w": 4,
+                        "x": 8,
+                        "y": 46
+                    },
+                    "id": 403,
+                    "options": {
+                        "colorMode": "value",
+                        "graphMode": "area",
+                        "justifyMode": "auto",
+                        "orientation": "auto",
+                        "percentChangeColorMode": "standard",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "showPercentChange": false,
+                        "textMode": "value",
+                        "wideLayout": true
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "sum(mcp_active_connections{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"})",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Active Connections",
+                    "type": "stat"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Current number of active SSE streaming connections",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "mappings": [],
+                            "noValue": "No sidecar data",
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "purple",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "short"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 4,
+                        "w": 4,
+                        "x": 12,
+                        "y": 46
+                    },
+                    "id": 404,
+                    "options": {
+                        "colorMode": "value",
+                        "graphMode": "area",
+                        "justifyMode": "auto",
+                        "orientation": "auto",
+                        "percentChangeColorMode": "standard",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "showPercentChange": false,
+                        "textMode": "value",
+                        "wideLayout": true
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "sum(mcp_sse_connections_active{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"})",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "SSE Connections",
+                    "type": "stat"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Median request latency (50th percentile)",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "decimals": 3,
+                            "mappings": [],
+                            "noValue": "No sidecar data",
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "yellow",
+                                        "value": 0.5
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 2
+                                    }
+                                ]
+                            },
+                            "unit": "s"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 4,
+                        "w": 4,
+                        "x": 16,
+                        "y": 46
+                    },
+                    "id": 405,
+                    "options": {
+                        "colorMode": "background",
+                        "graphMode": "area",
+                        "justifyMode": "auto",
+                        "orientation": "auto",
+                        "percentChangeColorMode": "standard",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "showPercentChange": false,
+                        "textMode": "value",
+                        "wideLayout": true
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "histogram_quantile(0.5, sum(rate(mcp_request_duration_seconds_bucket{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (le))",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "p50 Latency",
+                    "type": "stat"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "95th percentile request latency",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "decimals": 3,
+                            "mappings": [],
+                            "noValue": "No sidecar data",
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "yellow",
+                                        "value": 0.5
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 2
+                                    }
+                                ]
+                            },
+                            "unit": "s"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 4,
+                        "w": 4,
+                        "x": 20,
+                        "y": 46
+                    },
+                    "id": 406,
+                    "options": {
+                        "colorMode": "background",
+                        "graphMode": "area",
+                        "justifyMode": "auto",
+                        "orientation": "auto",
+                        "percentChangeColorMode": "standard",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "showPercentChange": false,
+                        "textMode": "value",
+                        "wideLayout": true
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "histogram_quantile(0.95, sum(rate(mcp_request_duration_seconds_bucket{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (le))",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "p95 Latency",
+                    "type": "stat"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Request rate broken down by JSON-RPC method",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "barWidthFactor": 0.6,
+                                "drawStyle": "line",
+                                "fillOpacity": 20,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 2,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "normal"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "reqps"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 12,
+                        "x": 0,
+                        "y": 50
+                    },
+                    "id": 407,
+                    "options": {
+                        "legend": {
+                            "calcs": [
+                                "mean",
+                                "max"
+                            ],
+                            "displayMode": "table",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "hideZeros": false,
+                            "mode": "multi",
+                            "sort": "desc"
+                        }
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "sum(rate(mcp_requests_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (method)",
+                            "legendFormat": "{{method}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Requests by Method",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Request rate by HTTP status code category",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "barWidthFactor": 0.6,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 2,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "reqps"
+                        },
+                        "overrides": [
+                            {
+                                "matcher": {
+                                    "id": "byRegexp",
+                                    "options": "2.."
+                                },
+                                "properties": [
+                                    {
+                                        "id": "color",
+                                        "value": {
+                                            "fixedColor": "green",
+                                            "mode": "fixed"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "matcher": {
+                                    "id": "byRegexp",
+                                    "options": "4.."
+                                },
+                                "properties": [
+                                    {
+                                        "id": "color",
+                                        "value": {
+                                            "fixedColor": "yellow",
+                                            "mode": "fixed"
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "matcher": {
+                                    "id": "byRegexp",
+                                    "options": "5.."
+                                },
+                                "properties": [
+                                    {
+                                        "id": "color",
+                                        "value": {
+                                            "fixedColor": "red",
+                                            "mode": "fixed"
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 12,
+                        "x": 12,
+                        "y": 50
+                    },
+                    "id": 408,
+                    "options": {
+                        "legend": {
+                            "calcs": [
+                                "mean",
+                                "max"
+                            ],
+                            "displayMode": "table",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "hideZeros": false,
+                            "mode": "multi",
+                            "sort": "desc"
+                        }
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "sum(rate(mcp_requests_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (status)",
+                            "legendFormat": "{{status}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Requests by Status",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Request latency percentiles (p50, p90, p95, p99) over time",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "barWidthFactor": 0.6,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 2,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "s"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 12,
+                        "x": 0,
+                        "y": 58
+                    },
+                    "id": 409,
+                    "options": {
+                        "legend": {
+                            "calcs": [
+                                "lastNotNull",
+                                "mean",
+                                "max"
+                            ],
+                            "displayMode": "table",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "hideZeros": false,
+                            "mode": "multi",
+                            "sort": "desc"
+                        }
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "histogram_quantile(0.50, sum(rate(mcp_request_duration_seconds_bucket{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (le))",
+                            "legendFormat": "p50",
+                            "refId": "A"
+                        },
+                        {
+                            "expr": "histogram_quantile(0.90, sum(rate(mcp_request_duration_seconds_bucket{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (le))",
+                            "legendFormat": "p90",
+                            "refId": "B"
+                        },
+                        {
+                            "expr": "histogram_quantile(0.95, sum(rate(mcp_request_duration_seconds_bucket{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (le))",
+                            "legendFormat": "p95",
+                            "refId": "C"
+                        },
+                        {
+                            "expr": "histogram_quantile(0.99, sum(rate(mcp_request_duration_seconds_bucket{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (le))",
+                            "legendFormat": "p99",
+                            "refId": "D"
+                        }
+                    ],
+                    "title": "Latency Percentiles",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "95th percentile latency broken down by JSON-RPC method",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "barWidthFactor": 0.6,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 2,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "s"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 12,
+                        "x": 12,
+                        "y": 58
+                    },
+                    "id": 410,
+                    "options": {
+                        "legend": {
+                            "calcs": [
+                                "lastNotNull",
+                                "mean",
+                                "max"
+                            ],
+                            "displayMode": "table",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "hideZeros": false,
+                            "mode": "multi",
+                            "sort": "desc"
+                        }
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "histogram_quantile(0.95, sum(rate(mcp_request_duration_seconds_bucket{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (le, method))",
+                            "legendFormat": "{{method}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "p95 Latency by Method",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Tool call rate broken down by tool name - shows which MCP tools are being used",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "barWidthFactor": 0.6,
+                                "drawStyle": "line",
+                                "fillOpacity": 20,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 2,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "normal"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "reqps"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 12,
+                        "x": 0,
+                        "y": 66
+                    },
+                    "id": 411,
+                    "options": {
+                        "legend": {
+                            "calcs": [
+                                "mean",
+                                "sum"
+                            ],
+                            "displayMode": "table",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "hideZeros": false,
+                            "mode": "multi",
+                            "sort": "desc"
+                        }
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "sum(rate(mcp_tool_calls_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (tool_name)",
+                            "legendFormat": "{{tool_name}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Tool Calls Over Time",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Top 10 most called MCP tools in the last 24 hours",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "short"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 12,
+                        "x": 12,
+                        "y": 66
+                    },
+                    "id": 412,
+                    "options": {
+                        "displayMode": "gradient",
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": false
+                        },
+                        "maxVizHeight": 300,
+                        "minVizHeight": 16,
+                        "minVizWidth": 8,
+                        "namePlacement": "auto",
+                        "orientation": "horizontal",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "showUnfilled": true,
+                        "sizing": "auto",
+                        "valueMode": "color"
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "topk(10, sum(increase(mcp_tool_calls_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[24h])) by (tool_name))",
+                            "legendFormat": "{{tool_name}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Top 10 Tools (24h)",
+                    "type": "bargauge"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Resource read rate broken down by resource URI",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "barWidthFactor": 0.6,
+                                "drawStyle": "line",
+                                "fillOpacity": 20,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 2,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "normal"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "reqps"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 12,
+                        "x": 0,
+                        "y": 74
+                    },
+                    "id": 413,
+                    "options": {
+                        "legend": {
+                            "calcs": [
+                                "mean",
+                                "sum"
+                            ],
+                            "displayMode": "table",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "hideZeros": false,
+                            "mode": "multi",
+                            "sort": "desc"
+                        }
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "sum(rate(mcp_resource_reads_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (resource_uri)",
+                            "legendFormat": "{{resource_uri}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Resource Reads Over Time",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Top 10 most accessed MCP resources in the last 24 hours",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "short"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 12,
+                        "x": 12,
+                        "y": 74
+                    },
+                    "id": 414,
+                    "options": {
+                        "displayMode": "gradient",
+                        "legend": {
+                            "calcs": [],
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": false
+                        },
+                        "maxVizHeight": 300,
+                        "minVizHeight": 16,
+                        "minVizWidth": 8,
+                        "namePlacement": "auto",
+                        "orientation": "horizontal",
+                        "reduceOptions": {
+                            "calcs": [
+                                "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                        },
+                        "showUnfilled": true,
+                        "sizing": "auto",
+                        "valueMode": "color"
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "topk(10, sum(increase(mcp_resource_reads_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[24h])) by (resource_uri))",
+                            "legendFormat": "{{resource_uri}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Top 10 Resources (24h)",
+                    "type": "bargauge"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Number of active SSE connections over time",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "barWidthFactor": 0.6,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 2,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "min": 0,
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "short"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 8,
+                        "x": 0,
+                        "y": 82
+                    },
+                    "id": 415,
+                    "options": {
+                        "legend": {
+                            "calcs": [
+                                "lastNotNull",
+                                "mean",
+                                "max"
+                            ],
+                            "displayMode": "table",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "hideZeros": false,
+                            "mode": "multi",
+                            "sort": "desc"
+                        }
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "sum(mcp_sse_connections_active{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}) by (mcpserver)",
+                            "legendFormat": "{{mcpserver}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Active SSE Connections",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "SSE connection duration percentiles showing how long connections stay open",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "barWidthFactor": 0.6,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 2,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "s"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 8,
+                        "x": 8,
+                        "y": 82
+                    },
+                    "id": 416,
+                    "options": {
+                        "legend": {
+                            "calcs": [
+                                "lastNotNull",
+                                "mean"
+                            ],
+                            "displayMode": "table",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "hideZeros": false,
+                            "mode": "multi",
+                            "sort": "desc"
+                        }
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "histogram_quantile(0.50, sum(rate(mcp_sse_connection_duration_seconds_bucket{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (le))",
+                            "legendFormat": "p50",
+                            "refId": "A"
+                        },
+                        {
+                            "expr": "histogram_quantile(0.95, sum(rate(mcp_sse_connection_duration_seconds_bucket{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (le))",
+                            "legendFormat": "p95",
+                            "refId": "B"
+                        }
+                    ],
+                    "title": "SSE Connection Duration",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "SSE event throughput by event type",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "barWidthFactor": 0.6,
+                                "drawStyle": "line",
+                                "fillOpacity": 20,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 2,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "normal"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "reqps"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 8,
+                        "x": 16,
+                        "y": 82
+                    },
+                    "id": 417,
+                    "options": {
+                        "legend": {
+                            "calcs": [
+                                "mean",
+                                "sum"
+                            ],
+                            "displayMode": "table",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "hideZeros": false,
+                            "mode": "multi",
+                            "sort": "desc"
+                        }
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "sum(rate(mcp_sse_events_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (event_type)",
+                            "legendFormat": "{{event_type}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "SSE Events by Type",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Error rate broken down by JSON-RPC method",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "barWidthFactor": 0.6,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 2,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "reqps"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 12,
+                        "x": 0,
+                        "y": 90
+                    },
+                    "id": 418,
+                    "options": {
+                        "legend": {
+                            "calcs": [
+                                "mean",
+                                "sum"
+                            ],
+                            "displayMode": "table",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "hideZeros": false,
+                            "mode": "multi",
+                            "sort": "desc"
+                        }
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "sum(rate(mcp_request_errors_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (method)",
+                            "legendFormat": "{{method}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Errors by Method",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Error rate broken down by JSON-RPC error code",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "palette-classic"
+                            },
+                            "custom": {
+                                "axisBorderShow": false,
+                                "axisCenteredZero": false,
+                                "axisColorMode": "text",
+                                "axisLabel": "",
+                                "axisPlacement": "auto",
+                                "barAlignment": 0,
+                                "barWidthFactor": 0.6,
+                                "drawStyle": "line",
+                                "fillOpacity": 10,
+                                "gradientMode": "none",
+                                "hideFrom": {
+                                    "legend": false,
+                                    "tooltip": false,
+                                    "viz": false
+                                },
+                                "insertNulls": false,
+                                "lineInterpolation": "linear",
+                                "lineWidth": 2,
+                                "pointSize": 5,
+                                "scaleDistribution": {
+                                    "type": "linear"
+                                },
+                                "showPoints": "never",
+                                "spanNulls": false,
+                                "stacking": {
+                                    "group": "A",
+                                    "mode": "none"
+                                },
+                                "thresholdsStyle": {
+                                    "mode": "off"
+                                }
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    }
+                                ]
+                            },
+                            "unit": "reqps"
+                        },
+                        "overrides": []
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 12,
+                        "x": 12,
+                        "y": 90
+                    },
+                    "id": 419,
+                    "options": {
+                        "legend": {
+                            "calcs": [
+                                "mean",
+                                "sum"
+                            ],
+                            "displayMode": "table",
+                            "placement": "bottom",
+                            "showLegend": true
+                        },
+                        "tooltip": {
+                            "hideZeros": false,
+                            "mode": "multi",
+                            "sort": "desc"
+                        }
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "sum(rate(mcp_request_errors_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[5m])) by (error_code)",
+                            "legendFormat": "{{error_code}}",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Errors by Code",
+                    "type": "timeseries"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus"
+                    },
+                    "description": "Recent errors in the last hour broken down by method and error code",
+                    "fieldConfig": {
+                        "defaults": {
+                            "color": {
+                                "mode": "thresholds"
+                            },
+                            "custom": {
+                                "align": "auto",
+                                "cellOptions": {
+                                    "type": "auto"
+                                },
+                                "inspect": false
+                            },
+                            "mappings": [],
+                            "thresholds": {
+                                "mode": "absolute",
+                                "steps": [
+                                    {
+                                        "color": "green",
+                                        "value": null
+                                    },
+                                    {
+                                        "color": "yellow",
+                                        "value": 1
+                                    },
+                                    {
+                                        "color": "red",
+                                        "value": 10
+                                    }
+                                ]
+                            }
+                        },
+                        "overrides": [
+                            {
+                                "matcher": {
+                                    "id": "byName",
+                                    "options": "Value"
+                                },
+                                "properties": [
+                                    {
+                                        "id": "displayName",
+                                        "value": "Error Count"
+                                    },
+                                    {
+                                        "id": "custom.cellOptions",
+                                        "value": {
+                                            "mode": "gradient",
+                                            "type": "color-background"
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "gridPos": {
+                        "h": 8,
+                        "w": 24,
+                        "x": 0,
+                        "y": 98
+                    },
+                    "id": 420,
+                    "options": {
+                        "cellHeight": "sm",
+                        "footer": {
+                            "countRows": false,
+                            "fields": "",
+                            "reducer": [
+                                "sum"
+                            ],
+                            "show": false
+                        },
+                        "showHeader": true,
+                        "sortBy": [
+                            {
+                                "desc": true,
+                                "displayName": "Error Count"
+                            }
+                        ]
+                    },
+                    "pluginVersion": "12.1.1",
+                    "targets": [
+                        {
+                            "expr": "sum(increase(mcp_request_errors_total{namespace=~\"$namespace\", mcpserver=~\"$mcpserver\"}[1h])) by (mcpserver, method, error_code) > 0",
+                            "format": "table",
+                            "instant": true,
+                            "legendFormat": "",
+                            "refId": "A"
+                        }
+                    ],
+                    "title": "Error Log (Last Hour)",
+                    "transformations": [
+                        {
+                            "id": "organize",
+                            "options": {
+                                "excludeByName": {
+                                    "Time": true
+                                },
+                                "indexByName": {
+                                    "Time": 0,
+                                    "Value": 4,
+                                    "error_code": 3,
+                                    "mcpserver": 1,
+                                    "method": 2
+                                },
+                                "renameByName": {
+                                    "error_code": "Error Code",
+                                    "mcpserver": "MCP Server",
+                                    "method": "Method"
+                                }
+                            }
+                        }
+                    ],
+                    "type": "table"
+                }
+            ],
+            "title": "Sidecar Metrics",
+            "type": "row"
         }
     ],
     "preload": false,
@@ -1729,10 +3467,71 @@
         "mcp",
         "operator",
         "protocol",
-        "validation"
+        "validation",
+        "sidecar",
+        "metrics"
     ],
     "templating": {
-        "list": []
+        "list": [
+            {
+                "allValue": ".*",
+                "current": {
+                    "selected": true,
+                    "text": "All",
+                    "value": "$__all"
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                },
+                "definition": "label_values(mcp_requests_total, namespace)",
+                "hide": 0,
+                "includeAll": true,
+                "label": "Namespace",
+                "multi": false,
+                "name": "namespace",
+                "options": [],
+                "query": {
+                    "qryType": 1,
+                    "query": "label_values(mcp_requests_total, namespace)",
+                    "refId": "PrometheusVariableQueryEditor-VariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "type": "query"
+            },
+            {
+                "allValue": ".*",
+                "current": {
+                    "selected": true,
+                    "text": "All",
+                    "value": "$__all"
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "prometheus"
+                },
+                "definition": "label_values(mcp_requests_total{namespace=~\"$namespace\"}, mcpserver)",
+                "hide": 0,
+                "includeAll": true,
+                "label": "MCP Server",
+                "multi": true,
+                "name": "mcpserver",
+                "options": [],
+                "query": {
+                    "qryType": 1,
+                    "query": "label_values(mcp_requests_total{namespace=~\"$namespace\"}, mcpserver)",
+                    "refId": "PrometheusVariableQueryEditor-VariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "type": "query"
+            }
+        ]
     },
     "time": {
         "from": "now-24h",

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,394 @@
+# MCP Server Metrics Guide
+
+Per-server metrics collection for MCP servers using the mcp-proxy sidecar.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Quick Start](#quick-start)
+- [Available Metrics](#available-metrics)
+- [Grafana Dashboard](#grafana-dashboard)
+- [Example Queries](#example-queries)
+- [Prometheus Alerts](#prometheus-alerts)
+- [Troubleshooting](#troubleshooting)
+
+## Overview
+
+The MCP Operator can inject a metrics sidecar (mcp-proxy) into your MCP server pods. This sidecar:
+
+- **Intercepts traffic** - Acts as a reverse proxy in front of your MCP server
+- **Parses JSON-RPC** - Understands MCP protocol for detailed metrics
+- **Exposes Prometheus metrics** - Tool calls, resource reads, latencies, errors
+- **Minimal overhead** - Sub-millisecond latency, ~20MB memory
+
+## Quick Start
+
+Enable metrics on any MCPServer with a single line:
+
+```yaml
+apiVersion: mcp.mcp-operator.io/v1
+kind: MCPServer
+metadata:
+  name: my-mcp-server
+spec:
+  image: your-registry/your-mcp-server:latest
+  transport:
+    type: http
+    config:
+      http:
+        port: 3001
+  metrics:
+    enabled: true  # That's it!
+```
+
+When `metrics.enabled: true`, the operator:
+
+1. Injects the mcp-proxy sidecar container
+2. Routes traffic through the proxy (port 8080 -> 3001)
+3. Exposes metrics on port 9090
+
+## Available Metrics
+
+### Request Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `mcp_requests_total` | Counter | `method`, `status`, `namespace`, `mcpserver` | Total requests by JSON-RPC method and HTTP status |
+| `mcp_request_duration_seconds` | Histogram | `method`, `namespace`, `mcpserver` | Request latency in seconds |
+| `mcp_request_size_bytes` | Histogram | `method`, `namespace`, `mcpserver` | Request body size |
+| `mcp_response_size_bytes` | Histogram | `method`, `namespace`, `mcpserver` | Response body size |
+| `mcp_request_errors_total` | Counter | `method`, `error_code`, `namespace`, `mcpserver` | JSON-RPC errors by method and code |
+
+### Connection Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `mcp_active_connections` | Gauge | `namespace`, `mcpserver` | Current active HTTP connections |
+| `mcp_proxy_info` | Gauge | `version`, `target`, `namespace`, `mcpserver` | Static proxy metadata |
+
+### MCP-Specific Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `mcp_tool_calls_total` | Counter | `tool_name`, `namespace`, `mcpserver` | Tool invocations by tool name |
+| `mcp_resource_reads_total` | Counter | `resource_uri`, `namespace`, `mcpserver` | Resource reads by URI |
+
+### SSE Metrics (Legacy Transport)
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `mcp_sse_connections_total` | Counter | `namespace`, `mcpserver` | Total SSE connections established |
+| `mcp_sse_connections_active` | Gauge | `namespace`, `mcpserver` | Currently active SSE streams |
+| `mcp_sse_events_total` | Counter | `event_type`, `namespace`, `mcpserver` | SSE events by type |
+| `mcp_sse_connection_duration_seconds` | Histogram | `namespace`, `mcpserver` | How long SSE connections stay open |
+
+## Grafana Dashboard
+
+The MCP Operator Grafana dashboard includes a **Sidecar Metrics** section with the following panels:
+
+### Overview Row
+- **Request Rate** - Current requests per second
+- **Error Rate** - Percentage of failed requests
+- **Active Connections** - HTTP connections
+- **SSE Connections** - Active streaming connections
+- **p50 Latency** - Median request latency
+- **p95 Latency** - 95th percentile latency
+
+### Request Traffic Row
+- **Requests by Method** - Traffic breakdown by JSON-RPC method
+- **Requests by Status** - Success vs errors by HTTP status code
+
+### Latency Row
+- **Latency Percentiles** - p50, p90, p95, p99 over time
+- **p95 Latency by Method** - Latency breakdown by JSON-RPC method
+
+### MCP Protocol Usage Row
+- **Tool Calls Over Time** - Which tools are being called
+- **Top 10 Tools (24h)** - Most used tools
+- **Resource Reads Over Time** - Resource access patterns
+- **Top 10 Resources (24h)** - Most accessed resources
+
+### SSE Connections Row
+- **Active SSE Connections** - Streaming connections over time
+- **SSE Connection Duration** - How long connections stay open
+- **SSE Events by Type** - Event throughput
+
+### Errors Row
+- **Errors by Method** - Which methods are failing
+- **Errors by Code** - JSON-RPC error code distribution
+- **Error Log (Last Hour)** - Detailed error breakdown table
+
+### Using the Dashboard
+
+1. Use the **Namespace** dropdown to filter by Kubernetes namespace
+2. Use the **MCP Server** dropdown to filter by specific servers
+3. Expand the "Sidecar Metrics" section (collapsed by default)
+
+## Example Queries
+
+### Request Rate
+
+```promql
+# Overall request rate
+sum(rate(mcp_requests_total[5m]))
+
+# Request rate by method
+sum(rate(mcp_requests_total[5m])) by (method)
+
+# Request rate for specific server
+sum(rate(mcp_requests_total{mcpserver="my-server"}[5m]))
+```
+
+### Latency
+
+```promql
+# p95 latency overall
+histogram_quantile(0.95, sum(rate(mcp_request_duration_seconds_bucket[5m])) by (le))
+
+# p95 latency by method
+histogram_quantile(0.95, sum(rate(mcp_request_duration_seconds_bucket[5m])) by (le, method))
+
+# Average latency
+rate(mcp_request_duration_seconds_sum[5m]) / rate(mcp_request_duration_seconds_count[5m])
+```
+
+### Error Rate
+
+```promql
+# Error rate percentage
+100 * (
+  sum(rate(mcp_request_errors_total[5m]))
+  /
+  sum(rate(mcp_requests_total[5m]))
+)
+
+# Errors by code
+sum(rate(mcp_request_errors_total[5m])) by (error_code)
+```
+
+### Tool Usage
+
+```promql
+# Tool call rate by tool name
+sum(rate(mcp_tool_calls_total[5m])) by (tool_name)
+
+# Top 10 tools in last 24 hours
+topk(10, sum(increase(mcp_tool_calls_total[24h])) by (tool_name))
+```
+
+### Resource Access
+
+```promql
+# Resource read rate
+sum(rate(mcp_resource_reads_total[5m])) by (resource_uri)
+
+# Top 10 resources in last 24 hours
+topk(10, sum(increase(mcp_resource_reads_total[24h])) by (resource_uri))
+```
+
+### SSE Connections
+
+```promql
+# Active SSE connections
+sum(mcp_sse_connections_active)
+
+# SSE connection duration p95
+histogram_quantile(0.95, sum(rate(mcp_sse_connection_duration_seconds_bucket[5m])) by (le))
+```
+
+## Prometheus Alerts
+
+Example alert rules for MCP server metrics:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: mcp-sidecar-alerts
+  namespace: mcp-operator-system
+spec:
+  groups:
+    - name: mcp-sidecar
+      interval: 30s
+      rules:
+        # High error rate
+        - alert: MCPServerHighErrorRate
+          expr: |
+            100 * (
+              sum(rate(mcp_request_errors_total[5m])) by (mcpserver, namespace)
+              /
+              sum(rate(mcp_requests_total[5m])) by (mcpserver, namespace)
+            ) > 5
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "High error rate for {{ $labels.mcpserver }}"
+            description: "MCPServer {{ $labels.mcpserver }} in {{ $labels.namespace }} has error rate {{ $value | humanize }}%"
+
+        # Critical error rate
+        - alert: MCPServerCriticalErrorRate
+          expr: |
+            100 * (
+              sum(rate(mcp_request_errors_total[5m])) by (mcpserver, namespace)
+              /
+              sum(rate(mcp_requests_total[5m])) by (mcpserver, namespace)
+            ) > 25
+          for: 2m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Critical error rate for {{ $labels.mcpserver }}"
+            description: "MCPServer {{ $labels.mcpserver }} in {{ $labels.namespace }} has error rate {{ $value | humanize }}%"
+
+        # High latency
+        - alert: MCPServerHighLatency
+          expr: |
+            histogram_quantile(0.95,
+              sum(rate(mcp_request_duration_seconds_bucket[5m])) by (le, mcpserver, namespace)
+            ) > 2
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "High latency for {{ $labels.mcpserver }}"
+            description: "MCPServer {{ $labels.mcpserver }} p95 latency is {{ $value | humanize }}s"
+
+        # No traffic (potential issue)
+        - alert: MCPServerNoTraffic
+          expr: |
+            sum(rate(mcp_requests_total[15m])) by (mcpserver, namespace) == 0
+            and
+            up{job=~".*mcp.*"} == 1
+          for: 30m
+          labels:
+            severity: info
+          annotations:
+            summary: "No traffic for {{ $labels.mcpserver }}"
+            description: "MCPServer {{ $labels.mcpserver }} has received no requests for 30 minutes"
+
+        # SSE connection issues
+        - alert: MCPServerSSEConnectionDrops
+          expr: |
+            increase(mcp_sse_connections_total[5m]) > 0
+            and
+            mcp_sse_connections_active == 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "SSE connections failing for {{ $labels.mcpserver }}"
+            description: "SSE connections are being established but immediately closing"
+```
+
+## Advanced Configuration
+
+### Custom Metrics Port
+
+```yaml
+spec:
+  metrics:
+    enabled: true
+    port: 9091  # Custom port
+```
+
+### Custom Sidecar Resources
+
+```yaml
+spec:
+  metrics:
+    enabled: true
+  sidecar:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
+```
+
+### Pin Sidecar Version
+
+```yaml
+spec:
+  metrics:
+    enabled: true
+  sidecar:
+    image: ghcr.io/vitorbari/mcp-proxy:v0.1.0
+```
+
+### TLS Termination
+
+```yaml
+spec:
+  metrics:
+    enabled: true
+  sidecar:
+    tls:
+      enabled: true
+      secretName: mcp-tls-secret
+      minVersion: "1.3"
+```
+
+## Troubleshooting
+
+### Metrics Not Appearing
+
+**Check sidecar is running:**
+
+```bash
+kubectl get pods -l app=my-mcp-server -o jsonpath='{.items[0].spec.containers[*].name}'
+# Should show both: mcp-server mcp-proxy
+```
+
+**Check sidecar logs:**
+
+```bash
+kubectl logs -l app=my-mcp-server -c mcp-proxy
+```
+
+**Test metrics endpoint:**
+
+```bash
+kubectl port-forward svc/my-mcp-server 9090:9090
+curl http://localhost:9090/metrics | grep mcp_
+```
+
+### No Data in Dashboard
+
+1. Verify `metrics.enabled: true` in MCPServer spec
+2. Check that Prometheus is scraping the metrics endpoint
+3. Ensure namespace and mcpserver filters are correct
+4. Send some test traffic to the MCP server
+
+### High Latency Added by Sidecar
+
+The sidecar adds < 1ms overhead. If you see significant latency:
+
+1. Check sidecar CPU limits aren't being throttled
+2. Increase CPU limits for high-throughput scenarios:
+
+```yaml
+sidecar:
+  resources:
+    limits:
+      cpu: 500m
+```
+
+### Sidecar OOMKilled
+
+Increase memory limits:
+
+```yaml
+sidecar:
+  resources:
+    limits:
+      memory: 256Mi
+```
+
+## See Also
+
+- [Sidecar Architecture](sidecar-architecture.md) - Technical deep-dive
+- [Monitoring Guide](monitoring.md) - Operator-level metrics
+- [Configuration Guide](configuration-guide.md) - All MCPServer options


### PR DESCRIPTION
## Summary

- Add collapsible "Sidecar Metrics" section to the MCP Operator Grafana dashboard with 20 new panels
- Add namespace and mcpserver templating variables for filtering by specific servers
- Create comprehensive docs/metrics.md documentation for sidecar metrics

## Dashboard Structure

The new sidecar metrics section includes:

**Overview Row (6 stat panels)**
- Request Rate, Error Rate, Active Connections, SSE Connections, p50/p95 Latency

**Request Traffic Row**
- Requests by Method (stacked time series)
- Requests by Status (with color coding: 2xx=green, 4xx=yellow, 5xx=red)

**Latency Row**
- Latency Percentiles (p50, p90, p95, p99)
- p95 Latency by Method

**MCP Protocol Usage Row**
- Tool Calls Over Time
- Top 10 Tools (24h bar gauge)
- Resource Reads Over Time
- Top 10 Resources (24h bar gauge)

**SSE Connections Row**
- Active SSE Connections
- SSE Connection Duration
- SSE Events by Type

**Errors Row**
- Errors by Method
- Errors by Code
- Error Log (Last Hour) - table with MCP Server, Method, Error Code, Count

## Documentation

The new `docs/metrics.md` includes:
- Quick start guide
- Complete metrics reference table
- Example Prometheus queries
- Alert rule examples for error rate and latency
- Advanced configuration (custom port, resources, TLS)
- Troubleshooting guide

## Test plan

- [ ] Import updated dashboard into Grafana
- [ ] Verify existing panels still work
- [ ] Deploy MCPServer with metrics enabled
- [ ] Generate traffic through sidecar proxy
- [ ] Verify new panels populate correctly
- [ ] Test with MCPServer without metrics (should show "No sidecar data")
- [ ] Test namespace/mcpserver variable filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)