### PR TITLE
fix(sidecar): avoid port conflict when MCP server uses port 8080

### DIFF
--- a/api/v1/mcpserver_types.go
+++ b/api/v1/mcpserver_types.go
@@ -389,6 +389,8 @@ const (
 	DefaultMetricsPort = int32(9090)
 	// DefaultSidecarPort is the default port the sidecar listens on
 	DefaultSidecarPort = int32(8080)
+	// FallbackSidecarPort is used when the MCP server port conflicts with DefaultSidecarPort
+	FallbackSidecarPort = int32(8081)
 	// DefaultSidecarCPURequest is the default CPU request for the sidecar
 	DefaultSidecarCPURequest = "50m"
 	// DefaultSidecarMemoryRequest is the default memory request for the sidecar
@@ -420,6 +422,14 @@ type SidecarConfig struct {
 	// Default: ghcr.io/vitorbari/mcp-proxy:latest
 	// +optional
 	Image string `json:"image,omitempty"`
+
+	// Port specifies the port the sidecar listens on for incoming MCP traffic.
+	// When not specified, defaults to 8080 unless the MCP server is also configured
+	// to use port 8080, in which case it defaults to 8081 to avoid conflicts.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=65535
+	// +optional
+	Port int32 `json:"port,omitempty"`
 
 	// Resources for the sidecar container.
 	// Default: requests: 50m CPU, 64Mi memory; limits: 200m CPU, 128Mi memory

--- a/config/crd/bases/mcp.mcp-operator.io_mcpservers.yaml
+++ b/config/crd/bases/mcp.mcp-operator.io_mcpservers.yaml
@@ -3363,6 +3363,15 @@ spec:
                       Image overrides the default sidecar image.
                       Default: ghcr.io/vitorbari/mcp-proxy:latest
                     type: string
+                  port:
+                    description: |-
+                      Port specifies the port the sidecar listens on for incoming MCP traffic.
+                      When not specified, defaults to 8080 unless the MCP server is also configured
+                      to use port 8080, in which case it defaults to 8081 to avoid conflicts.
+                    format: int32
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
                   resources:
                     description: |-
                       Resources for the sidecar container.

--- a/internal/transport/http.go
+++ b/internal/transport/http.go
@@ -315,11 +315,11 @@ func (h *HTTPResourceManager) buildService(mcpServer *mcpv1.MCPServer) *corev1.S
 	annotations["service.beta.kubernetes.io/aws-load-balancer-backend-protocol"] = "http"
 	annotations["service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout"] = "3600"
 
-	// When sidecar is injected, the service points to sidecar port (8080)
-	// The sidecar then proxies to the MCP server on localhost
+	// When sidecar is injected, the service points to the sidecar port.
+	// The sidecar then proxies to the MCP server on localhost.
 	servicePort := port
 	if h.shouldInjectSidecar(mcpServer) {
-		servicePort = mcpv1.DefaultSidecarPort
+		servicePort = h.getSidecarPort(mcpServer)
 	}
 
 	service := utils.BuildService(mcpServer, servicePort, corev1.ProtocolTCP, annotations)
@@ -371,15 +371,22 @@ func (h *HTTPResourceManager) getSidecarImage(mcpServer *mcpv1.MCPServer) string
 	return mcpv1.DefaultSidecarImage
 }
 
+// getSidecarPort returns the port the sidecar listens on.
+// Delegates to the package-level GetSidecarPort function.
+func (h *HTTPResourceManager) getSidecarPort(mcpServer *mcpv1.MCPServer) int32 {
+	return GetSidecarPort(mcpServer)
+}
+
 // buildSidecarContainer builds the metrics sidecar container
 func (h *HTTPResourceManager) buildSidecarContainer(mcpServer *mcpv1.MCPServer, targetPort int32) corev1.Container {
 	metricsPort := h.getMetricsPort(mcpServer)
 	sidecarImage := h.getSidecarImage(mcpServer)
+	sidecarPort := h.getSidecarPort(mcpServer)
 
 	// Build sidecar args
 	args := []string{
 		fmt.Sprintf("--target-addr=localhost:%d", targetPort),
-		fmt.Sprintf("--listen-addr=:%d", mcpv1.DefaultSidecarPort),
+		fmt.Sprintf("--listen-addr=:%d", sidecarPort),
 		fmt.Sprintf("--metrics-addr=:%d", metricsPort),
 		"--log-level=info",
 	}
@@ -403,7 +410,7 @@ func (h *HTTPResourceManager) buildSidecarContainer(mcpServer *mcpv1.MCPServer, 
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          "mcp",
-				ContainerPort: mcpv1.DefaultSidecarPort,
+				ContainerPort: sidecarPort,
 				Protocol:      corev1.ProtocolTCP,
 			},
 			{


### PR DESCRIPTION
Add configurable sidecar.port field to allow explicit port configuration. When not specified, the sidecar now uses smart defaults:
- If MCP server port is 8080 (same as default sidecar port), automatically use port 8081 to avoid conflicts
- Otherwise, use the default port 8080

This prevents container port conflicts when metrics.enabled=true and the MCP server is configured to use port 8080.