### PR TITLE
feat: add CRD short names and categories for better UX

### DIFF
--- a/api/v1/mcpserver_types.go
+++ b/api/v1/mcpserver_types.go
@@ -736,6 +736,7 @@ type ValidationIssue struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:shortName=mcp;mcps,categories={mcp-operator}
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Replicas",type=integer,JSONPath=`.status.replicas`
 // +kubebuilder:printcolumn:name="Ready",type=integer,JSONPath=`.status.readyReplicas`

--- a/config/crd/bases/mcp.mcp-operator.io_mcpservers.yaml
+++ b/config/crd/bases/mcp.mcp-operator.io_mcpservers.yaml
@@ -8,9 +8,14 @@ metadata:
 spec:
   group: mcp.mcp-operator.io
   names:
+    categories:
+    - mcp-operator
     kind: MCPServer
     listKind: MCPServerList
     plural: mcpservers
+    shortNames:
+    - mcp
+    - mcps
     singular: mcpserver
   scope: Namespaced
   versions:


### PR DESCRIPTION
Add kubebuilder resource marker to enable:
- Short names: users can now use `kubectl get mcp` or `kubectl get mcps`
- Categories: resources included in `kubectl get mcp-operator` queries